### PR TITLE
add sink connector for ob-mysql

### DIFF
--- a/flink-connector-oceanbase/pom.xml
+++ b/flink-connector-oceanbase/pom.xml
@@ -31,4 +31,31 @@ See the Mulan PSL v2 for more details.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-api-java-bridge</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>druid</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/flink-connector-oceanbase/pom.xml
+++ b/flink-connector-oceanbase/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2023 OceanBase
+flink-connector-oceanbase is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+        http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.oceanbase</groupId>
+    <artifactId>flink-connector-oceanbase-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>flink-connector-oceanbase</artifactId>
+  <name>Flink : Connectors : OceanBase</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+</project>

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionOptions.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionOptions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.connection;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+public class OceanBaseConnectionOptions implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String url;
+    private final String username;
+    private final String password;
+    private final Properties connectionProperties;
+
+    public OceanBaseConnectionOptions(
+            String url, String username, String password, Properties connectionProperties) {
+        this.url = url;
+        this.username = username;
+        this.password = password;
+        this.connectionProperties = connectionProperties;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Properties getConnectionProperties() {
+        return connectionProperties;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionPool.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionPool.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.connection;
+
+import com.alibaba.druid.pool.DruidDataSource;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class OceanBaseConnectionPool implements OceanBaseConnectionProvider, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final OceanBaseConnectionOptions options;
+    private DruidDataSource dataSource;
+    private volatile boolean inited = false;
+
+    public OceanBaseConnectionPool(OceanBaseConnectionOptions options) {
+        this.options = options;
+    }
+
+    public void init() throws SQLException {
+        if (!inited) {
+            synchronized (this) {
+                if (!inited) {
+                    dataSource = new DruidDataSource();
+                    dataSource.setUrl(options.getUrl());
+                    dataSource.setUsername(options.getUsername());
+                    dataSource.setPassword(options.getPassword());
+                    dataSource.configFromPropety(options.getConnectionProperties());
+                    dataSource.init();
+                    inited = true;
+                }
+            }
+        }
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        init();
+        return dataSource.getConnection();
+    }
+
+    @Override
+    public void close() {
+        if (dataSource != null) {
+            dataSource.close();
+            dataSource = null;
+        }
+        inited = false;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionProvider.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/connection/OceanBaseConnectionProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.connection;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public interface OceanBaseConnectionProvider extends AutoCloseable {
+
+    /**
+     * Attempts to establish a connection
+     *
+     * @return a connection to OceanBase
+     * @throws SQLException if a database access error occurs
+     */
+    Connection getConnection() throws SQLException;
+
+    /**
+     * Attempts to get the compatible mode of OceanBase
+     *
+     * @return compatible mode
+     * @throws SQLException if a database access error occurs
+     */
+    default String getCompatibleMode() throws SQLException {
+        try (Connection conn = getConnection()) {
+            ResultSet rs =
+                    conn.createStatement()
+                            .executeQuery("SHOW VARIABLES LIKE 'ob_compatibility_mode'");
+            while (rs.next()) {
+                return rs.getString("Value");
+            }
+            return null;
+        }
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseDialect.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseDialect.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.dialect;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface OceanBaseDialect {
+
+    /**
+     * Quotes the identifier
+     *
+     * @param identifier identifier
+     * @return the quoted identifier
+     */
+    String quoteIdentifier(@Nonnull String identifier);
+
+    /**
+     * Gets the upsert statement
+     *
+     * @param tableName table name
+     * @param fieldNames field names list
+     * @param uniqueKeyFields unique key field names list
+     * @return the statement string
+     */
+    String getUpsertStatement(
+            @Nonnull String tableName,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<String> uniqueKeyFields);
+
+    /**
+     * Gets the exist statement
+     *
+     * @param tableName table name
+     * @param uniqueKeyFields unique key field names list
+     * @return the statement string
+     */
+    default String getExistStatement(
+            @Nonnull String tableName, @Nonnull List<String> uniqueKeyFields) {
+        String conditionClause =
+                uniqueKeyFields.stream()
+                        .map(f -> String.format("%s = ?", quoteIdentifier(f)))
+                        .collect(Collectors.joining(" AND "));
+        return "SELECT 1 FROM " + quoteIdentifier(tableName) + " WHERE " + conditionClause;
+    }
+
+    /**
+     * Gets the insert statement
+     *
+     * @param tableName table name
+     * @param fieldNames field names list
+     * @return the statement string
+     */
+    default String getInsertIntoStatement(
+            @Nonnull String tableName, @Nonnull List<String> fieldNames) {
+        String columns =
+                fieldNames.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+        String placeholders = String.join(", ", Collections.nCopies(fieldNames.size(), "?"));
+        return "INSERT INTO "
+                + quoteIdentifier(tableName)
+                + "("
+                + columns
+                + ")"
+                + " VALUES ("
+                + placeholders
+                + ")";
+    }
+
+    /**
+     * Gets the update statement
+     *
+     * @param tableName table name
+     * @param fieldNames field names list
+     * @param uniqueKeyFields unique key field names list
+     * @return the statement string
+     */
+    default String getUpdateStatement(
+            @Nonnull String tableName,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<String> uniqueKeyFields) {
+        String setClause =
+                fieldNames.stream()
+                        .filter(f -> !uniqueKeyFields.contains(f))
+                        .map(f -> String.format("%s = ?", quoteIdentifier(f)))
+                        .collect(Collectors.joining(", "));
+        String conditionClause =
+                uniqueKeyFields.stream()
+                        .map(f -> String.format("%s = ?", quoteIdentifier(f)))
+                        .collect(Collectors.joining(" AND "));
+        return "UPDATE "
+                + quoteIdentifier(tableName)
+                + " SET "
+                + setClause
+                + " WHERE "
+                + conditionClause;
+    }
+
+    /**
+     * Gets the delete statement
+     *
+     * @param tableName table name
+     * @param uniqueKeyFields unique key field names list
+     * @return the statement string
+     */
+    default String getDeleteStatement(
+            @Nonnull String tableName, @Nonnull List<String> uniqueKeyFields) {
+        String conditionClause =
+                uniqueKeyFields.stream()
+                        .map(f -> String.format("%s = ?", quoteIdentifier(f)))
+                        .collect(Collectors.joining(" AND "));
+        return "DELETE FROM " + quoteIdentifier(tableName) + " WHERE " + conditionClause;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialect.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialect.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.dialect;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OceanBaseMySQLDialect implements OceanBaseDialect {
+
+    @Override
+    public String quoteIdentifier(@Nonnull String identifier) {
+        return "`" + identifier + "`";
+    }
+
+    @Override
+    public String getUpsertStatement(
+            @Nonnull String tableName,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<String> uniqueKeyFields) {
+        String updateClause =
+                fieldNames.stream()
+                        .filter(f -> !uniqueKeyFields.contains(f))
+                        .map(f -> quoteIdentifier(f) + "=VALUES(" + quoteIdentifier(f) + ")")
+                        .collect(Collectors.joining(", "));
+        return getInsertIntoStatement(tableName, fieldNames)
+                + " ON DUPLICATE KEY UPDATE "
+                + updateClause;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseOracleDialect.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseOracleDialect.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.dialect;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+
+public class OceanBaseOracleDialect implements OceanBaseDialect {
+
+    @Override
+    public String quoteIdentifier(@Nonnull String identifier) {
+        return identifier;
+    }
+
+    @Override
+    public String getUpsertStatement(
+            @Nonnull String tableName,
+            @Nonnull List<String> fieldNames,
+            @Nonnull List<String> uniqueKeyFields) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseRowDataStatementExecutor.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseRowDataStatementExecutor.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import com.oceanbase.connector.flink.connection.OceanBaseConnectionProvider;
+import com.oceanbase.connector.flink.dialect.OceanBaseDialect;
+import com.oceanbase.connector.flink.table.OceanBaseTableSchema;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OceanBaseRowDataStatementExecutor implements OceanBaseStatementExecutor<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SinkWriterMetricGroup metricGroup;
+    private final OceanBaseWriterOptions options;
+    private final OceanBaseTableSchema tableSchema;
+    private final OceanBaseConnectionProvider connectionProvider;
+    private final String existStatementSql;
+    private final String insertStatementSql;
+    private final String updateStatementSql;
+    private final String deleteStatementSql;
+    private final String upsertStatementSql;
+
+    private final List<RowData> buffer = new ArrayList<>();
+    private final Map<String, Tuple2<Boolean, RowData>> reduceBuffer = new HashMap<>();
+
+    private transient volatile boolean closed = false;
+
+    public OceanBaseRowDataStatementExecutor(
+            Sink.InitContext context,
+            OceanBaseWriterOptions options,
+            OceanBaseTableSchema tableSchema,
+            OceanBaseConnectionProvider connectionProvider,
+            OceanBaseDialect dialect) {
+        this.metricGroup = context.metricGroup();
+        this.options = options;
+        this.tableSchema = tableSchema;
+        this.connectionProvider = connectionProvider;
+        this.existStatementSql =
+                dialect.getExistStatement(options.getTableName(), tableSchema.getKeyFieldNames());
+        this.insertStatementSql =
+                dialect.getInsertIntoStatement(options.getTableName(), tableSchema.getFieldNames());
+        this.updateStatementSql =
+                dialect.getUpdateStatement(
+                        options.getTableName(),
+                        tableSchema.getFieldNames(),
+                        tableSchema.getKeyFieldNames());
+        this.deleteStatementSql =
+                dialect.getDeleteStatement(options.getTableName(), tableSchema.getKeyFieldNames());
+        this.upsertStatementSql =
+                dialect.getUpsertStatement(
+                        options.getTableName(),
+                        tableSchema.getFieldNames(),
+                        tableSchema.getKeyFieldNames());
+    }
+
+    @Override
+    public void addToBatch(RowData record) {
+        if (record.getArity() != tableSchema.getFieldNames().size()) {
+            throw new RuntimeException(
+                    "Record fields number "
+                            + record.getArity()
+                            + "doesn't match sql columns "
+                            + tableSchema.getFieldNames().size());
+        }
+        boolean flag = changeFlag(record.getRowKind());
+        if (!tableSchema.isHasKey() && flag) {
+            synchronized (buffer) {
+                buffer.add(record);
+            }
+        } else {
+            String key = constructKey(record, tableSchema.getKeyFieldGetters());
+            synchronized (reduceBuffer) {
+                reduceBuffer.put(key, Tuple2.of(flag, record));
+            }
+        }
+        metricGroup.getIOMetricGroup().getNumRecordsInCounter().inc();
+    }
+
+    /**
+     * Returns true if the row kind is INSERT or UPDATE_AFTER, returns false if the row kind is
+     * DELETE or UPDATE_BEFORE.
+     *
+     * @param rowKind row kind
+     * @return change flag
+     */
+    private boolean changeFlag(RowKind rowKind) {
+        switch (rowKind) {
+            case INSERT:
+            case UPDATE_AFTER:
+                return true;
+            case DELETE:
+            case UPDATE_BEFORE:
+                return false;
+            default:
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unknown row kind, the supported row kinds is: INSERT, UPDATE_BEFORE, UPDATE_AFTER,"
+                                        + " DELETE, but get: %s.",
+                                rowKind));
+        }
+    }
+
+    /**
+     * Constructs a unique key for the record
+     *
+     * @param rowData row data
+     * @param keyFieldGetters the field getters of key fields
+     * @return key string
+     */
+    private String constructKey(RowData rowData, RowData.FieldGetter[] keyFieldGetters) {
+        StringBuilder key = new StringBuilder();
+        for (RowData.FieldGetter fieldGetter : keyFieldGetters) {
+            Object obj = fieldGetter.getFieldOrNull(rowData);
+            key.append(obj == null ? "null" : obj.toString());
+            key.append("#");
+        }
+        return key.toString();
+    }
+
+    @Override
+    public void executeBatch() throws SQLException {
+        if (!tableSchema.isHasKey()) {
+            synchronized (buffer) {
+                executeBatch(insertStatementSql, buffer, tableSchema.getFieldGetters());
+                buffer.clear();
+            }
+        } else {
+            synchronized (reduceBuffer) {
+                List<RowData> writeBuffer = new ArrayList<>();
+                List<RowData> deleteBuffer = new ArrayList<>();
+                for (Tuple2<Boolean, RowData> tuple2 : reduceBuffer.values()) {
+                    if (tuple2.f0) {
+                        writeBuffer.add(tuple2.f1);
+                    } else {
+                        deleteBuffer.add(tuple2.f1);
+                    }
+                }
+                if (options.isUpsertMode()) {
+                    executeBatch(upsertStatementSql, writeBuffer, tableSchema.getFieldGetters());
+                } else {
+                    List<RowData> updateBuffer = new ArrayList<>();
+                    List<RowData> insertBuffer = new ArrayList<>();
+                    for (RowData rowData : writeBuffer) {
+                        if (closed) {
+                            break;
+                        }
+                        if (exist(rowData)) {
+                            updateBuffer.add(rowData);
+                        } else {
+                            insertBuffer.add(rowData);
+                        }
+                    }
+                    executeBatch(
+                            updateStatementSql,
+                            updateBuffer,
+                            tableSchema.getNonKeyFieldGetters(),
+                            tableSchema.getKeyFieldGetters());
+                    executeBatch(insertStatementSql, insertBuffer, tableSchema.getFieldGetters());
+                }
+                executeBatch(deleteStatementSql, deleteBuffer, tableSchema.getKeyFieldGetters());
+                reduceBuffer.clear();
+            }
+        }
+    }
+
+    /**
+     * Checks whether the row data exists
+     *
+     * @param rowData row data
+     * @return true if the row data exists
+     * @throws SQLException if a database access error occurs
+     */
+    private boolean exist(RowData rowData) throws SQLException {
+        if (closed || rowData == null) {
+            return true;
+        }
+        try (Connection connection = connectionProvider.getConnection()) {
+            PreparedStatement statement = connection.prepareStatement(existStatementSql);
+            setStatementData(statement, rowData, tableSchema.getKeyFieldGetters());
+            ResultSet resultSet = statement.executeQuery();
+            return resultSet.next();
+        }
+    }
+
+    private void executeBatch(
+            String sql, List<RowData> rowDataList, RowData.FieldGetter[]... fieldGetters)
+            throws SQLException {
+        if (closed || rowDataList == null || rowDataList.isEmpty()) {
+            return;
+        }
+        try (Connection connection = connectionProvider.getConnection()) {
+            PreparedStatement statement = connection.prepareStatement(sql);
+            int count = 0;
+            for (RowData rowData : rowDataList) {
+                setStatementData(statement, rowData, fieldGetters);
+                statement.addBatch();
+                count++;
+                if (!closed && count >= options.getBatchSize()) {
+                    statement.executeBatch();
+                    metricGroup.getIOMetricGroup().getNumRecordsOutCounter().inc(count);
+                    count = 0;
+                }
+            }
+            if (!closed && count > 0) {
+                statement.executeBatch();
+                metricGroup.getIOMetricGroup().getNumRecordsOutCounter().inc(count);
+            }
+        }
+    }
+
+    private void setStatementData(
+            PreparedStatement statement, RowData row, RowData.FieldGetter[]... fieldGetters)
+            throws SQLException {
+        if (row != null) {
+            int index = 1;
+            for (int i = 0; i < fieldGetters.length; i++) {
+                for (int j = 0; j < fieldGetters[i].length; j++) {
+                    Object obj = fieldGetters[i][j].getFieldOrNull(row);
+                    if (obj == null) {
+                        statement.setObject(index++, null);
+                    } else {
+                        statement.setString(index++, obj.toString());
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!closed) {
+            closed = true;
+
+            if (connectionProvider != null) {
+                connectionProvider.close();
+            }
+        }
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseSink.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseSink.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+
+import com.oceanbase.connector.flink.connection.OceanBaseConnectionProvider;
+import com.oceanbase.connector.flink.dialect.OceanBaseDialect;
+import com.oceanbase.connector.flink.dialect.OceanBaseMySQLDialect;
+import com.oceanbase.connector.flink.dialect.OceanBaseOracleDialect;
+import com.oceanbase.connector.flink.table.OceanBaseTableSchema;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class OceanBaseSink implements Sink<RowData> {
+
+    private final TypeSerializer<RowData> serializer;
+    private final OceanBaseWriterOptions writerOptions;
+    private final OceanBaseTableSchema tableSchema;
+    private final OceanBaseConnectionProvider connectionProvider;
+
+    public OceanBaseSink(
+            TypeSerializer<RowData> serializer,
+            OceanBaseWriterOptions writerOptions,
+            OceanBaseTableSchema tableSchema,
+            OceanBaseConnectionProvider connectionProvider) {
+        this.serializer = serializer;
+        this.writerOptions = writerOptions;
+        this.tableSchema = tableSchema;
+        this.connectionProvider = connectionProvider;
+    }
+
+    @Override
+    public SinkWriter<RowData> createWriter(InitContext context) throws IOException {
+        OceanBaseStatementExecutor statementExecutor =
+                new OceanBaseRowDataStatementExecutor(
+                        context,
+                        writerOptions,
+                        tableSchema,
+                        connectionProvider,
+                        getDialect(connectionProvider));
+        return new OceanBaseWriter<>(serializer, writerOptions, statementExecutor);
+    }
+
+    private OceanBaseDialect getDialect(OceanBaseConnectionProvider connectionProvider)
+            throws IOException {
+        String compatibleMode;
+        try {
+            compatibleMode = connectionProvider.getCompatibleMode();
+        } catch (SQLException e) {
+            throw new IOException("Failed to get compatible mode", e);
+        }
+
+        if (compatibleMode != null) {
+            compatibleMode = compatibleMode.toLowerCase();
+        }
+
+        switch (compatibleMode) {
+            case "mysql":
+                return new OceanBaseMySQLDialect();
+            case "oracle":
+                return new OceanBaseOracleDialect();
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported compatible mode: " + compatibleMode);
+        }
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseStatementExecutor.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseStatementExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+public interface OceanBaseStatementExecutor<T> extends AutoCloseable, Serializable {
+
+    /**
+     * Adds a record to batch
+     *
+     * @param record the row data record
+     */
+    void addToBatch(T record);
+
+    /**
+     * Submits a batch of records to OceanBase
+     *
+     * @throws SQLException if a database access error occurs
+     */
+    void executeBatch() throws SQLException;
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseWriter.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseWriter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class OceanBaseWriter<T> implements SinkWriter<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OceanBaseWriter.class);
+
+    private final TypeSerializer<T> serializer;
+    private final OceanBaseWriterOptions writerOptions;
+    private final OceanBaseStatementExecutor<T> statementExecutor;
+
+    private transient ScheduledExecutorService scheduler;
+    private transient ScheduledFuture<?> scheduledFuture;
+    private transient int bufferCount = 0;
+    private transient volatile Exception flushException = null;
+    private transient volatile boolean closed = false;
+
+    public OceanBaseWriter(
+            TypeSerializer<T> serializer,
+            OceanBaseWriterOptions writerOptions,
+            OceanBaseStatementExecutor<T> statementExecutor) {
+        this.serializer = serializer;
+        this.writerOptions = writerOptions;
+        this.statementExecutor = statementExecutor;
+
+        this.scheduler =
+                new ScheduledThreadPoolExecutor(
+                        1, new ExecutorThreadFactory("OceanBaseWriter.scheduler"));
+        this.scheduledFuture =
+                this.scheduler.scheduleWithFixedDelay(
+                        () -> {
+                            if (!closed) {
+                                try {
+                                    synchronized (this) {
+                                        flush(false);
+                                    }
+                                } catch (Exception e) {
+                                    flushException = e;
+                                }
+                            }
+                        },
+                        writerOptions.getBatchIntervalMs(),
+                        writerOptions.getBatchIntervalMs(),
+                        TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public synchronized void write(T record, Context context)
+            throws IOException, InterruptedException {
+        checkFlushException();
+
+        T recordCopy = copyIfNecessary(record);
+        statementExecutor.addToBatch(recordCopy);
+        bufferCount++;
+        if (bufferCount >= writerOptions.getBufferSize()) {
+            flush(false);
+        }
+    }
+
+    protected void checkFlushException() {
+        if (flushException != null) {
+            throw new RuntimeException("Writing records to OceanBase failed.", flushException);
+        }
+    }
+
+    private T copyIfNecessary(T record) {
+        return serializer == null ? record : serializer.copy(record);
+    }
+
+    @Override
+    public synchronized void flush(boolean endOfInput) throws IOException, InterruptedException {
+        checkFlushException();
+
+        for (int i = 0; i <= writerOptions.getMaxRetries(); i++) {
+            try {
+                statementExecutor.executeBatch();
+                bufferCount = 0;
+                break;
+            } catch (SQLException e) {
+                LOG.error("OceanBaseWriter flush error, retry times = {}", i, e);
+                if (i >= writerOptions.getMaxRetries()) {
+                    throw new IOException(e);
+                }
+                Thread.sleep(1000 * i);
+            }
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!closed) {
+            closed = true;
+
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(false);
+                scheduler.shutdown();
+            }
+
+            if (bufferCount > 0) {
+                try {
+                    flush(true);
+                } catch (Exception e) {
+                    LOG.warn("Writing records to OceanBase failed", e);
+                    throw new RuntimeException("Writing records to OceanBase failed", e);
+                }
+            }
+
+            try {
+                if (statementExecutor != null) {
+                    statementExecutor.close();
+                }
+            } catch (Exception e) {
+                LOG.warn("Close statement executor failed", e);
+            }
+        }
+        checkFlushException();
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseWriterOptions.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseWriterOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import java.io.Serializable;
+
+public class OceanBaseWriterOptions implements Serializable {
+
+    private final String tableName;
+    private final boolean upsertMode;
+
+    private final long batchIntervalMs;
+    private final int bufferSize;
+    private final int batchSize;
+    private final int maxRetries;
+
+    public OceanBaseWriterOptions(
+            String tableName,
+            boolean upsertMode,
+            long batchIntervalMs,
+            int bufferSize,
+            int batchSize,
+            int maxRetries) {
+        this.tableName = tableName;
+        this.upsertMode = upsertMode;
+        this.batchIntervalMs = batchIntervalMs;
+        this.bufferSize = bufferSize;
+        this.batchSize = batchSize;
+        this.maxRetries = maxRetries;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public boolean isUpsertMode() {
+        return upsertMode;
+    }
+
+    public long getBatchIntervalMs() {
+        return batchIntervalMs;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/OceanBaseConnectorOptions.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/OceanBaseConnectorOptions.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+
+import com.oceanbase.connector.flink.connection.OceanBaseConnectionOptions;
+import com.oceanbase.connector.flink.sink.OceanBaseWriterOptions;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+
+public class OceanBaseConnectorOptions implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final ConfigOption<String> URL =
+            ConfigOptions.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The JDBC database URL.");
+
+    public static final ConfigOption<String> TABLE_NAME =
+            ConfigOptions.key("table-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The table name.");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The username.");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The password.");
+
+    public static final ConfigOption<String> CONNECTION_PROPERTIES =
+            ConfigOptions.key("connection-properties")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Connection properties.");
+
+    public static final ConfigOption<Boolean> UPSERT_MODE =
+            ConfigOptions.key("upsert-mode")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Flag of whether to use upsert mode.");
+
+    public static final ConfigOption<Duration> BUFFER_FLUSH_INTERVAL =
+            ConfigOptions.key("buffer-flush.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            "The flush interval mills, over this time, asynchronous threads will flush data.");
+
+    public static final ConfigOption<Integer> BUFFER_SIZE =
+            ConfigOptions.key("buffer-flush.buffer-size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("The flush batch size of records buffer.");
+
+    public static final ConfigOption<Integer> BUFFER_BATCH_SIZE =
+            ConfigOptions.key("buffer-flush.batch-size")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("The flush batch size of records buffer.");
+
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("max-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("The max retry times if writing records to database failed.");
+    private final ReadableConfig allConfig;
+
+    public OceanBaseConnectorOptions(Map<String, String> allOptions) {
+        this.allConfig = Configuration.fromMap(allOptions);
+    }
+
+    public OceanBaseConnectionOptions getConnectionOptions() {
+        return new OceanBaseConnectionOptions(
+                allConfig.get(URL),
+                allConfig.get(USERNAME),
+                allConfig.get(PASSWORD),
+                parseProperties(allConfig.get(CONNECTION_PROPERTIES)));
+    }
+
+    public OceanBaseWriterOptions getWriterOptions() {
+        return new OceanBaseWriterOptions(
+                allConfig.get(TABLE_NAME),
+                allConfig.get(UPSERT_MODE),
+                allConfig.get(BUFFER_FLUSH_INTERVAL).toMillis(),
+                allConfig.get(BUFFER_SIZE).intValue(),
+                allConfig.get(BUFFER_BATCH_SIZE).intValue(),
+                allConfig.get(MAX_RETRIES).intValue());
+    }
+
+    private Properties parseProperties(String propsStr) {
+        Properties props = new Properties();
+        if (StringUtils.isBlank(propsStr)) {
+            return props;
+        }
+        for (String propStr : propsStr.split(";")) {
+            if (StringUtils.isBlank(propStr)) {
+                continue;
+            }
+            String[] pair = propStr.trim().split("=");
+            if (pair.length != 2) {
+                throw new IllegalArgumentException("properties must have one key value pair");
+            }
+            props.put(pair[0].trim(), pair[1].trim());
+        }
+        return props;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/OceanBaseTableSchema.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/OceanBaseTableSchema.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.table;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OceanBaseTableSchema implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> fieldNames;
+    private final RowData.FieldGetter[] fieldGetters;
+    private final boolean hasKey;
+    private final List<String> keyFieldNames;
+    private final RowData.FieldGetter[] keyFieldGetters;
+    private final RowData.FieldGetter[] nonKeyFieldGetters;
+
+    public OceanBaseTableSchema(ResolvedSchema schema) {
+        this.fieldNames = schema.getColumnNames();
+        this.fieldGetters = new RowData.FieldGetter[this.fieldNames.size()];
+        this.hasKey = schema.getPrimaryKey().isPresent();
+        this.keyFieldNames =
+                schema.getPrimaryKey().map(UniqueConstraint::getColumns).orElse(new ArrayList<>());
+        this.keyFieldGetters = new RowData.FieldGetter[this.keyFieldNames.size()];
+        this.nonKeyFieldGetters =
+                new RowData.FieldGetter[this.fieldNames.size() - this.keyFieldNames.size()];
+        int k = 0, n = 0;
+        for (int i = 0; i < this.fieldNames.size(); i++) {
+            RowData.FieldGetter fieldGetter =
+                    RowData.createFieldGetter(
+                            schema.getColumnDataTypes().get(i).getLogicalType(), i);
+            this.fieldGetters[i] = fieldGetter;
+            if (this.keyFieldNames.contains(this.fieldNames.get(i))) {
+                this.keyFieldGetters[k++] = fieldGetter;
+            } else {
+                this.nonKeyFieldGetters[n++] = fieldGetter;
+            }
+        }
+    }
+
+    public List<String> getFieldNames() {
+        return fieldNames;
+    }
+
+    public RowData.FieldGetter[] getFieldGetters() {
+        return fieldGetters;
+    }
+
+    public boolean isHasKey() {
+        return hasKey;
+    }
+
+    public List<String> getKeyFieldNames() {
+        return keyFieldNames;
+    }
+
+    public RowData.FieldGetter[] getKeyFieldGetters() {
+        return keyFieldGetters;
+    }
+
+    public RowData.FieldGetter[] getNonKeyFieldGetters() {
+        return nonKeyFieldGetters;
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/sink/OceanBaseDynamicTableSink.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/sink/OceanBaseDynamicTableSink.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.table.sink;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.ProviderContext;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import com.oceanbase.connector.flink.connection.OceanBaseConnectionPool;
+import com.oceanbase.connector.flink.connection.OceanBaseConnectionProvider;
+import com.oceanbase.connector.flink.sink.OceanBaseSink;
+import com.oceanbase.connector.flink.sink.OceanBaseWriterOptions;
+import com.oceanbase.connector.flink.table.OceanBaseConnectorOptions;
+import com.oceanbase.connector.flink.table.OceanBaseTableSchema;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+public class OceanBaseDynamicTableSink implements DynamicTableSink {
+
+    private final ResolvedSchema physicalSchema;
+    private final OceanBaseConnectorOptions connectorOptions;
+
+    public OceanBaseDynamicTableSink(
+            ResolvedSchema physicalSchema, OceanBaseConnectorOptions connectorOptions) {
+        this.physicalSchema = physicalSchema;
+        this.connectorOptions = connectorOptions;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        validatePrimaryKey(requestedMode);
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.DELETE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .build();
+    }
+
+    private void validatePrimaryKey(ChangelogMode requestedMode) {
+        checkState(
+                ChangelogMode.insertOnly().equals(requestedMode)
+                        || physicalSchema.getPrimaryKey().isPresent(),
+                "please declare primary key for sink table when query contains update/delete record.");
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        OceanBaseWriterOptions writerOptions = connectorOptions.getWriterOptions();
+        OceanBaseTableSchema tableSchema = new OceanBaseTableSchema(physicalSchema);
+        OceanBaseConnectionProvider connectionProvider =
+                new OceanBaseConnectionPool(connectorOptions.getConnectionOptions());
+        return new DataStreamSinkProvider() {
+            @Override
+            public DataStreamSink<?> consumeDataStream(
+                    ProviderContext providerContext, DataStream<RowData> dataStream) {
+                final boolean objectReuse =
+                        dataStream.getExecutionEnvironment().getConfig().isObjectReuseEnabled();
+                TypeSerializer<RowData> typeSerializer =
+                        objectReuse
+                                ? dataStream
+                                        .getType()
+                                        .createSerializer(dataStream.getExecutionConfig())
+                                : null;
+                Sink<RowData> sink =
+                        new OceanBaseSink(
+                                typeSerializer, writerOptions, tableSchema, connectionProvider);
+                return dataStream.sinkTo(sink);
+            }
+        };
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new OceanBaseDynamicTableSink(physicalSchema, connectorOptions);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "OceanBase";
+    }
+}

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/sink/OceanBaseDynamicTableSinkFactory.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/table/sink/OceanBaseDynamicTableSinkFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 OceanBase
+ * flink-connector-oceanbase is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *         http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+package com.oceanbase.connector.flink.table.sink;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import com.oceanbase.connector.flink.table.OceanBaseConnectorOptions;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OceanBaseDynamicTableSinkFactory implements DynamicTableSinkFactory {
+
+    public static final String IDENTIFIER = "oceanbase";
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validate();
+
+        ResolvedSchema resolvedSchema = context.getCatalogTable().getResolvedSchema();
+        ResolvedSchema physicalSchema =
+                new ResolvedSchema(
+                        resolvedSchema.getColumns().stream()
+                                .filter(Column::isPhysical)
+                                .collect(Collectors.toList()),
+                        resolvedSchema.getWatermarkSpecs(),
+                        resolvedSchema.getPrimaryKey().orElse(null));
+        OceanBaseConnectorOptions options =
+                new OceanBaseConnectorOptions(context.getCatalogTable().getOptions());
+        return new OceanBaseDynamicTableSink(physicalSchema, options);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(OceanBaseConnectorOptions.URL);
+        options.add(OceanBaseConnectorOptions.TABLE_NAME);
+        options.add(OceanBaseConnectorOptions.USERNAME);
+        options.add(OceanBaseConnectorOptions.PASSWORD);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(OceanBaseConnectorOptions.CONNECTION_PROPERTIES);
+        options.add(OceanBaseConnectorOptions.UPSERT_MODE);
+        options.add(OceanBaseConnectorOptions.BUFFER_FLUSH_INTERVAL);
+        options.add(OceanBaseConnectorOptions.BUFFER_SIZE);
+        options.add(OceanBaseConnectorOptions.BUFFER_BATCH_SIZE);
+        options.add(OceanBaseConnectorOptions.MAX_RETRIES);
+        return options;
+    }
+}

--- a/flink-connector-oceanbase/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-oceanbase/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 OceanBase
+# flink-connector-oceanbase is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#         http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+com.oceanbase.connector.flink.table.sink.OceanBaseDynamicTableSinkFactory

--- a/flink-connector-oceanbase/src/test/resources/log4j2-test.properties
+++ b/flink-connector-oceanbase/src/test/resources/log4j2-test.properties
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 OceanBase
+# flink-connector-oceanbase is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#         http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+rootLogger.level = INFO
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,16 @@ See the Mulan PSL v2 for more details.
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.oceanbase</groupId>
-  <artifactId>flink-connector-oceanbase</artifactId>
+  <artifactId>flink-connector-oceanbase-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <name>Flink : Connectors : OceanBase : Parent</name>
+  <packaging>pom</packaging>
+  <inceptionYear>2023</inceptionYear>
 
-  <name>${project.groupId}:${project.artifactId}</name>
-  <description>Apache Flink Connector for OceanBase</description>
-  <url>https://github.com/oceanbase/flink-connector-oceanbase</url>
+  <organization>
+    <name>OceanBase</name>
+    <url>https://open.oceanbase.com</url>
+  </organization>
 
   <licenses>
     <license>
@@ -49,6 +53,10 @@ See the Mulan PSL v2 for more details.
       <timezone>+8</timezone>
     </developer>
   </developers>
+
+  <modules>
+    <module>flink-connector-oceanbase</module>
+  </modules>
 
   <properties>
     <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,42 @@ See the Mulan PSL v2 for more details.
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <flink.version>1.16.0</flink.version>
+    <scala.binary.version>2.12</scala.binary.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-table-api-java-bridge</artifactId>
+        <version>${flink.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-test-utils</artifactId>
+        <version>${flink.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+        <version>${flink.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.alibaba</groupId>
+        <artifactId>druid</artifactId>
+        <version>1.2.15</version>
+      </dependency>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>5.1.47</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <distributionManagement>
     <snapshotRepository>
@@ -76,5 +111,40 @@ See the Mulan PSL v2 for more details.
       <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.4.2</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.7</version>
+              <style>AOSP</style>
+            </googleJavaFormat>
+
+            <!-- \# refers to the static imports -->
+            <importOrder>
+              <order>org.apache.flink,org.apache.flink.shaded,,javax,java,scala,\#
+              </order>
+            </importOrder>
+
+            <removeUnusedImports/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
Implements `org.apache.flink.api.connector.sink2.Sink` with `OceanBaseSink`, only support mysql mode for now.