### PR TITLE
fix (sql compatibility): use sys_context to query tenant name on oracle mode

### DIFF
--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseOracleDialect.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseOracleDialect.java
@@ -86,6 +86,6 @@ public class OceanBaseOracleDialect implements OceanBaseDialect {
 
     @Override
     public String getQueryTenantNameStatement() {
-        return "SELECT TENANT_NAME FROM SYS.DBA_OB_TENANTS";
+        return "SELECT SYS_CONTEXT('USERENV', 'CON_NAME') FROM DUAL";
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Use sys_context to query tenant name on oracle mode. See https://www.oceanbase.com/docs/common-oceanbase-database-cn-1000000000512084

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
