### PR TITLE
fix: use INSERT IGNORE for primary key only table.

### DIFF
--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialect.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialect.java
@@ -16,8 +16,9 @@
 
 package com.oceanbase.connector.flink.dialect;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.util.function.SerializableFunction;
+
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -46,12 +47,11 @@ public class OceanBaseMySQLDialect implements OceanBaseDialect {
                         .filter(f -> !uniqueKeyFields.contains(f))
                         .map(f -> quoteIdentifier(f) + "=VALUES(" + quoteIdentifier(f) + ")")
                         .collect(Collectors.joining(", "));
-        String insertIntoStatement = getInsertIntoStatement(schemaName, tableName, fieldNames, placeholderFunc);
+        String insertIntoStatement =
+                getInsertIntoStatement(schemaName, tableName, fieldNames, placeholderFunc);
         if (StringUtils.isNotEmpty(updateClause)) {
             // ON DUPLICATE KEY UPDATE
-            return insertIntoStatement
-                    + " ON DUPLICATE KEY UPDATE "
-                    + updateClause;
+            return insertIntoStatement + " ON DUPLICATE KEY UPDATE " + updateClause;
         } else {
             // INSERT IGNORE
             return StringUtils.replace(insertIntoStatement, "INSERT", "INSERT IGNORE", 1);

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialectTest.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/dialect/OceanBaseMySQLDialectTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.connector.flink.dialect;
+
+import org.apache.flink.util.function.SerializableFunction;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class OceanBaseMySQLDialectTest {
+
+    @Test
+    void getUpsertStatementUpdate() {
+        OceanBaseMySQLDialect dialect = new OceanBaseMySQLDialect();
+        String upsertStatement =
+                dialect.getUpsertStatement(
+                        "sche1",
+                        "tb1",
+                        Stream.of("id", "name").collect(Collectors.toList()),
+                        Stream.of("id").collect(Collectors.toList()),
+                        (SerializableFunction<String, String>) s -> "?");
+        Assertions.assertEquals(
+                "INSERT INTO `sche1`.`tb1`(`id`, `name`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `name`=VALUES(`name`)",
+                upsertStatement);
+    }
+
+    @Test
+    void getUpsertStatementIgnore() {
+        OceanBaseMySQLDialect dialect = new OceanBaseMySQLDialect();
+        String upsertStatement =
+                dialect.getUpsertStatement(
+                        "sche1",
+                        "tb1",
+                        Stream.of("id").collect(Collectors.toList()),
+                        Stream.of("id").collect(Collectors.toList()),
+                        (SerializableFunction<String, String>) s -> "?");
+        Assertions.assertEquals(
+                "INSERT IGNORE INTO `sche1`.`tb1`(`id`) VALUES (?)", upsertStatement);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix primary key only table insert data fail issue.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->

use `ON DUPLICATE KEY UPDATE` for normal table.

use `INSERT IGNORE` for primary key table.
