### PR TITLE
hotfix: avoid test cases that may fall into infinite loops.

### DIFF
--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -481,8 +481,7 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
             throws InterruptedException {
         int tableRowsCount = 0;
         for (int i = 0; i < 100; ++i) {
-            tableRowsCount =
-                OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
+            tableRowsCount = OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
             if (tableRowsCount < expectedCount) {
                 Thread.sleep(100);
             }

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -45,6 +45,7 @@ import org.apache.flink.types.RowKind;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -359,7 +360,7 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
         env.fromElements((RowData) rowData).sinkTo(sink);
         env.execute();
 
-        waitForTableCount(tableName, 1);
+        waitingAndAssertTableCount(tableName, 1);
         List<String> actual =
                 queryTable(
                         tableName,
@@ -469,19 +470,24 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
                         "108,jacket,water resistent black wind breaker,0.1000000000",
                         "109,spare tire,24 inch spare tire,22.2000000000");
 
-        waitForTableCount(getTestTable(), expected.size());
+        waitingAndAssertTableCount(getTestTable(), expected.size());
 
         List<String> actual = queryTable(getTestTable());
 
         assertEqualsInAnyOrder(expected, actual);
     }
 
-    private void waitForTableCount(String tableName, int expectedCount)
+    private void waitingAndAssertTableCount(String tableName, int expectedCount)
             throws InterruptedException {
-        while (OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName)
-                < expectedCount) {
-            Thread.sleep(100);
+        int tableRowsCount = 0;
+        for (int i = 0; i < 100; ++i) {
+            tableRowsCount =
+                OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
+            if (tableRowsCount < expectedCount) {
+                Thread.sleep(100);
+            }
         }
+        Assert.assertEquals(tableRowsCount, expectedCount);
     }
 
     public List<String> queryTable(String tableName) throws SQLException {

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseOracleConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseOracleConnectorITCase.java
@@ -301,11 +301,10 @@ public class OceanBaseOracleConnectorITCase extends OceanBaseOracleTestBase {
     }
 
     private void waitingAndAssertTableCount(String tableName, int expectedCount)
-        throws InterruptedException {
+            throws InterruptedException {
         int tableRowsCount = 0;
         for (int i = 0; i < 100; ++i) {
-            tableRowsCount =
-                OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
+            tableRowsCount = OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
             if (tableRowsCount < expectedCount) {
                 Thread.sleep(100);
             }

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseOracleConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseOracleConnectorITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.types.RowKind;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -292,19 +293,24 @@ public class OceanBaseOracleConnectorITCase extends OceanBaseOracleTestBase {
                         "108,jacket,water resistent black wind breaker,0.1",
                         "109,spare tire,24 inch spare tire,22.2");
 
-        waitForTableCount(getTestTable(), expected.size());
+        waitingAndAssertTableCount(getTestTable(), expected.size());
 
         List<String> actual = queryTable(getTestTable());
 
         assertEqualsInAnyOrder(expected, actual);
     }
 
-    private void waitForTableCount(String tableName, int expectedCount)
-            throws InterruptedException {
-        while (OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName)
-                < expectedCount) {
-            Thread.sleep(100);
+    private void waitingAndAssertTableCount(String tableName, int expectedCount)
+        throws InterruptedException {
+        int tableRowsCount = 0;
+        for (int i = 0; i < 100; ++i) {
+            tableRowsCount =
+                OceanBaseJdbcUtils.getTableRowsCount(this::getConnection, tableName);
+            if (tableRowsCount < expectedCount) {
+                Thread.sleep(100);
+            }
         }
+        Assert.assertEquals(tableRowsCount, expectedCount);
     }
 
     public List<String> queryTable(String tableName) throws SQLException {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
`com.oceanbase.connector.flink.OceanBaseOracleConnectorITCase#waitForTableCount`
This method will cause some test cases that do not meet the expectations to fall into an infinite loop, never being able to exit.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
