### PR TITLE
test: start odp container with config url

### DIFF
--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -44,7 +44,7 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
     @Test
     public void testSink() throws Exception {
         Map<String, String> options = getOptions();
-        options.put("url", getConfigUrl());
+        options.put("url", getSysParameter("obconfig_url"));
         options.put("sys.username", getSysUsername());
         options.put("sys.password", getSysPassword());
 

--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 import org.testcontainers.lifecycle.Startables;
 
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +44,7 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
     @Test
     public void testSink() throws Exception {
         Map<String, String> options = getOptions();
-        options.put("url", getSysParameter("obconfig_url"));
+        options.put("url", getConfigUrl());
         options.put("sys.username", getSysUsername());
         options.put("sys.password", getSysPassword());
 
@@ -55,8 +54,7 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
     @Test
     public void testSinkWithODP() throws Exception {
         createSysUser("proxyro", getSysPassword());
-        try (OceanBaseProxyContainer odpContainer =
-                createOdpContainer(getRsListForODP(), getSysPassword())) {
+        try (OceanBaseProxyContainer odpContainer = createOdpContainer(getSysPassword())) {
             Startables.deepStart(Stream.of(odpContainer)).join();
 
             Map<String, String> options = getOptions();
@@ -147,11 +145,6 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
         assertEqualsInAnyOrder(expected2, actual2);
 
         dropTables("htable$family1", "htable$family2");
-    }
-
-    protected List<String> queryHTable(String tableName, RowConverter rowConverter)
-            throws SQLException {
-        return queryTable(tableName, Arrays.asList("K", "Q", "V"), rowConverter);
     }
 
     protected String integer(Integer n) {

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -23,10 +23,6 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.oceanbase.OceanBaseCEContainer;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.time.Duration;
 
 public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
@@ -60,25 +56,16 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @SuppressWarnings("resource")
-    public OceanBaseProxyContainer createOdpContainer(String rsList, String password) {
+    public OceanBaseProxyContainer createOdpContainer(String password) {
         return new OceanBaseProxyContainer("4.3.1.0-4")
                 .withNetwork(NETWORK)
-                .withClusterName(CLUSTER_NAME)
-                .withRsList(rsList)
+                .withConfigUrl(getConfigUrl())
                 .withPassword(password)
                 .withLogConsumer(new Slf4jLogConsumer(LOG));
     }
 
-    public String getRsListForODP() throws SQLException {
-        try (Connection connection = getSysJdbcConnection();
-                Statement statement = connection.createStatement()) {
-            String sql = "SELECT svr_ip, inner_port FROM oceanbase.__all_server;";
-            ResultSet rs = statement.executeQuery(sql);
-            if (rs.next()) {
-                return rs.getString("svr_ip") + ":" + rs.getString("inner_port");
-            }
-            throw new RuntimeException("Server ip and port not found");
-        }
+    public String getConfigUrl() {
+        return getSysParameter("obconfig_url");
     }
 
     @Override

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -59,9 +59,9 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
     public OceanBaseProxyContainer createOdpContainer(String proxyroPassword) {
         return new OceanBaseProxyContainer("4.3.1.0-4")
                 .withNetwork(NETWORK)
+                .withClusterName(CLUSTER_NAME)
                 .withConfigUrl(getOdpConfigUrl())
-                .withPassword(SYS_PASSWORD)
-                .withProxyroPassword(proxyroPassword)
+                .withPassword(proxyroPassword)
                 .withLogConsumer(new Slf4jLogConsumer(LOG));
     }
 

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -56,11 +56,12 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @SuppressWarnings("resource")
-    public OceanBaseProxyContainer createOdpContainer(String password) {
+    public OceanBaseProxyContainer createOdpContainer(String proxyroPassword) {
         return new OceanBaseProxyContainer("4.3.1.0-4")
                 .withNetwork(NETWORK)
                 .withConfigUrl(getOdpConfigUrl())
-                .withPassword(password)
+                .withPassword(SYS_PASSWORD)
+                .withProxyroPassword(proxyroPassword)
                 .withLogConsumer(new Slf4jLogConsumer(LOG));
     }
 

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -59,13 +59,15 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
     public OceanBaseProxyContainer createOdpContainer(String password) {
         return new OceanBaseProxyContainer("4.3.1.0-4")
                 .withNetwork(NETWORK)
-                .withConfigUrl(getConfigUrl())
+                .withConfigUrl(getOdpConfigUrl())
                 .withPassword(password)
                 .withLogConsumer(new Slf4jLogConsumer(LOG));
     }
 
-    public String getConfigUrl() {
-        return getSysParameter("obconfig_url");
+    public String getOdpConfigUrl() {
+        return String.format(
+                "http://%s:%d/services?Action=GetObProxyConfig",
+                CONTAINER.getHost(), CONTAINER.getMappedPort(CONFIG_SERVER_PORT));
     }
 
     @Override

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -32,8 +32,7 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
     private static final int RPC_PORT = 2885;
     private static final String APP_NAME = "flink_oceanbase_test";
 
-    private String clusterName = "obcluster";
-    private String rsList;
+    private String configUrl;
     private String password;
 
     public OceanBaseProxyContainer(String version) {
@@ -43,10 +42,9 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
 
     @Override
     protected void configure() {
-        assert rsList != null && password != null;
+        assert configUrl != null && password != null;
         addEnv("APP_NAME", APP_NAME);
-        addEnv("OB_CLUSTER", clusterName);
-        addEnv("RS_LIST", rsList);
+        addEnv("CONFIG_URL", configUrl);
         addEnv("PROXYRO_PASSWORD", password);
     }
 
@@ -55,13 +53,8 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
                 Arrays.asList(this.getMappedPort(SQL_PORT), this.getMappedPort(RPC_PORT)));
     }
 
-    public OceanBaseProxyContainer withClusterName(String clusterName) {
-        this.clusterName = clusterName;
-        return this;
-    }
-
-    public OceanBaseProxyContainer withRsList(String rsList) {
-        this.rsList = rsList;
+    public OceanBaseProxyContainer withConfigUrl(String configUrl) {
+        this.configUrl = configUrl;
         return this;
     }
 

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -29,9 +29,9 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
     private static final int RPC_PORT = 2885;
     private static final String APP_NAME = "flink_oceanbase_test";
 
+    private String clusterName = "obcluster";
     private String configUrl;
     private String password;
-    private String proxyroPassword;
 
     public OceanBaseProxyContainer(String version) {
         super(DockerImageName.parse(IMAGE + ":" + version));
@@ -42,8 +42,12 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
     protected void configure() {
         addEnv("APP_NAME", APP_NAME);
         addEnv("CONFIG_URL", Objects.requireNonNull(configUrl));
-        addEnv("PROXYSYS_PASSWORD", Objects.requireNonNull(password));
-        addEnv("PROXYRO_PASSWORD", Objects.requireNonNull(proxyroPassword));
+        addEnv("PROXYRO_PASSWORD", Objects.requireNonNull(password));
+    }
+
+    public OceanBaseProxyContainer withClusterName(String clusterName) {
+        this.clusterName = clusterName;
+        return this;
     }
 
     public OceanBaseProxyContainer withConfigUrl(String configUrl) {
@@ -56,14 +60,9 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
         return this;
     }
 
-    public OceanBaseProxyContainer withProxyroPassword(String proxyroPassword) {
-        this.proxyroPassword = proxyroPassword;
-        return this;
-    }
-
     @Override
     public String getUsername() {
-        return "root@proxysys";
+        return "proxyro@sys#" + clusterName;
     }
 
     @Override
@@ -91,6 +90,6 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
 
     @Override
     protected String getTestQueryString() {
-        return "SHOW PROXYCONFIG LIKE 'obproxy_config_server_url'";
+        return "SELECT 1";
     }
 }

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -91,6 +91,6 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
 
     @Override
     protected String getTestQueryString() {
-        return "SELECT 1";
+        return "SHOW PROXYCONFIG LIKE 'obproxy_config_server_url'";
     }
 }

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseTestBase.java
@@ -212,6 +212,11 @@ public abstract class OceanBaseTestBase implements OceanBaseMetadata {
         }
     }
 
+    public List<String> queryHTable(String tableName, RowConverter rowConverter)
+            throws SQLException {
+        return queryTable(tableName, Arrays.asList("K", "Q", "V"), rowConverter);
+    }
+
     @FunctionalInterface
     public interface RowConverter {
         String convert(ResultSet rs, int columnCount) throws SQLException;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Use CONFIG_URL to start the ODP container to avoid exceptions caused by splicing RS_LIST.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
