### PR TITLE
[FIX]:Modify the configuration of ODP mode parameters

### DIFF
--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -228,11 +228,11 @@ Once executed, the records should have been written to OceanBase.
 | table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.             |
 | username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                          |
 | password                 | Yes      |         | String   | The password of non-sys tenant.                                                                                          |
-| odp-mode                 | No       | false   | Boolean  | If the value of ODP-MODE is true, use the ODP mode to connect to OBKV.                                                   |
-| odp-ip                   | No       |         | String   | IP address of the ODP. When the value of odp-mode is true, it is required                                                |
-| odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. When the value of odp-mode is true, it is required.                                              |
-| sys.username             | No       |         | String   | The username of sys tenant.Required when using obconfig_url mode                                                         |
-| sys.password             | No       |         | String   | The password of sys tenant.Required when using obconfig_url mode                                                         |
+| odp-mode                 | No       | false   | Boolean  | If set to 'true', the connector will connect to OBKV via ODP.                                                 |
+| odp-ip                   | No       |         | String   | IP address of the ODP. Required if 'odp-mode' is set to 'true'.        |
+| odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. Required if 'odp-mode' is set to 'true'.                                             |
+| sys.username             | No       |         | String   | The username of sys tenant. Required if 'odp-mode' is set to 'false'.                                                          |
+| sys.password             | No       |         | String   | The password of sys tenant. Required if 'odp-mode' is set to 'false'.                                                        |
 | hbase.properties         | No       |         | String   | Properties to configure 'obkv-hbase-client-java', multiple values are separated by semicolons.                           |
 | sync-write               | No       | false   | Boolean  | Whether to write data synchronously, will not use buffer if it's set to 'true'.                                          |
 | buffer-flush.interval    | No       | 1s      | Duration | Buffer flush interval. Set '0' to disable scheduled flushing.                                                            |

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -72,7 +72,7 @@ CREATE TABLE `htable1$family1`
 
 Take Maven project for example, add the required dependencies to the pom.xml, and then use the following code.
 
-##### obconfig_url mode
+##### Connect using a URL
 
 ```java
 package com.oceanbase;
@@ -115,7 +115,7 @@ public class Main {
 }
 ```
 
-##### odp mode
+##### Connect using ODP mode
 
 ```java
 package com.oceanbase;
@@ -166,7 +166,7 @@ For more information please refer to [OBKVHBaseConnectorITCase.java](../../flink
 
 Put the JAR files of dependencies to the 'lib' directory of Flink, and then create the destination table with Flink SQL through the sql client.
 
-##### obconfig_url mode
+##### Connect using a URL
 
 ```sql
 CREATE TABLE t_sink
@@ -186,7 +186,7 @@ CREATE TABLE t_sink
   'sys.password'='');
 ```
 
-##### odp mode
+##### Connect using ODP mode
 
 ```sql
 CREATE TABLE t_sink
@@ -203,9 +203,7 @@ CREATE TABLE t_sink
   'schema-name'='test',
   'table-name'='htable1',
   'username'='root@test',
-  'password'='',
-  'sys.username'='root',
-  'sys.password'='');
+  'password'='');
 ```
 
 Insert records by Flink SQL.

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -221,20 +221,23 @@ Once executed, the records should have been written to OceanBase.
 
 ## Configuration
 
-|          Option          | Required | Default |   Type   |                                                 Description                                                  |
-|--------------------------|----------|---------|----------|--------------------------------------------------------------------------------------------------------------|
-| url                      | Yes      |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>.                          |
-| schema-name              | Yes      |         | String   | The database name of OceanBase.                                                                              |
-| table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>. |
-| username                 | Yes      |         | String   | The username of non-sys tenant.                                                                              |
-| password                 | Yes      |         | String   | The password of non-sys tenant.                                                                              |
-| sys.username             | Yes      |         | String   | The username of sys tenant.                                                                                  |
-| sys.password             | Yes      |         | String   | The password of sys tenant.                                                                                  |
-| hbase.properties         | No       |         | String   | Properties to configure 'obkv-hbase-client-java', multiple values are separated by semicolons.               |
-| sync-write               | No       | false   | Boolean  | Whether to write data synchronously, will not use buffer if it's set to 'true'.                              |
-| buffer-flush.interval    | No       | 1s      | Duration | Buffer flush interval. Set '0' to disable scheduled flushing.                                                |
-| buffer-flush.buffer-size | No       | 1000    | Integer  | Buffer size.                                                                                                 |
-| max-retries              | No       | 3       | Integer  | Max retry times on failure.                                                                                  |
+|          Option          | Required | Default |   Type   |                                                       Description                                                        |
+|--------------------------|----------|---------|----------|--------------------------------------------------------------------------------------------------------------------------|
+| url                      | Yes      |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>.Required when using obconfig_url mode |
+| schema-name              | Yes      |         | String   | The database name of OceanBase.                                                                                          |
+| table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.             |
+| username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                          |
+| password                 | Yes      |         | String   | The password of non-sys tenant.                                                                                          |
+| odp-mode                 | No       |         | Boolean  | If the value of ODP-MODE is true, use the ODP mode to connect to OBKV.                                                   |
+| odp-ip                   | No       |         | String   | IP address of the ODP. When the value of odp-mode is true, it is required                                                |
+| odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. When the value of odp-mode is true, it is required.                                              |
+| sys.username             | No       |         | String   | The username of sys tenant.Required when using obconfig_url mode                                                         |
+| sys.password             | No       |         | String   | The password of sys tenant.Required when using obconfig_url mode                                                         |
+| hbase.properties         | No       |         | String   | Properties to configure 'obkv-hbase-client-java', multiple values are separated by semicolons.                           |
+| sync-write               | No       | false   | Boolean  | Whether to write data synchronously, will not use buffer if it's set to 'true'.                                          |
+| buffer-flush.interval    | No       | 1s      | Duration | Buffer flush interval. Set '0' to disable scheduled flushing.                                                            |
+| buffer-flush.buffer-size | No       | 1000    | Integer  | Buffer size.                                                                                                             |
+| max-retries              | No       | 3       | Integer  | Max retry times on failure.                                                                                              |
 
 ## References
 

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -141,7 +141,7 @@ public class Main {
                         + "  'connector'='obkv-hbase',"
                         + "  'odp-mode'='true',"
                         + "  'odp-ip'='127.0.0.1',"
-                        + "  'odp-port'='12881',"
+                        + "  'odp-port'='2885',"
                         + "  'schema-name'='test',"
                         + "  'table-name'='htable1',"
                         + "  'username'='root@test',"
@@ -199,7 +199,7 @@ CREATE TABLE t_sink
   'connector'='obkv-hbase',
   'odp-mode'='true',
   'odp-ip'='127.0.0.1',
-  'odp-port'='12881',
+  'odp-port'='2885',
   'schema-name'='test',
   'table-name'='htable1',
   'username'='root@test',
@@ -228,7 +228,7 @@ Once executed, the records should have been written to OceanBase.
 | table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.             |
 | username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                          |
 | password                 | Yes      |         | String   | The password of non-sys tenant.                                                                                          |
-| odp-mode                 | No       |         | Boolean  | If the value of ODP-MODE is true, use the ODP mode to connect to OBKV.                                                   |
+| odp-mode                 | No       | false   | Boolean  | If the value of ODP-MODE is true, use the ODP mode to connect to OBKV.                                                   |
 | odp-ip                   | No       |         | String   | IP address of the ODP. When the value of odp-mode is true, it is required                                                |
 | odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. When the value of odp-mode is true, it is required.                                              |
 | sys.username             | No       |         | String   | The username of sys tenant.Required when using obconfig_url mode                                                         |

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -223,7 +223,7 @@ Once executed, the records should have been written to OceanBase.
 
 |          Option          | Required | Default |   Type   |                                                       Description                                                        |
 |--------------------------|----------|---------|----------|--------------------------------------------------------------------------------------------------------------------------|
-| url                      | Yes      |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>.Required when using obconfig_url mode |
+| url                      | No      |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>. Required when 'odp-mode' is set to 'false'. |
 | schema-name              | Yes      |         | String   | The database name of OceanBase.                                                                                          |
 | table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.             |
 | username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                          |

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -219,23 +219,23 @@ Once executed, the records should have been written to OceanBase.
 
 ## Configuration
 
-|          Option          | Required | Default |   Type   |                                                       Description                                                        |
-|--------------------------|----------|---------|----------|--------------------------------------------------------------------------------------------------------------------------|
-| url                      | No      |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>. Required when 'odp-mode' is set to 'false'. |
-| schema-name              | Yes      |         | String   | The database name of OceanBase.                                                                                          |
-| table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.             |
-| username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                          |
-| password                 | Yes      |         | String   | The password of non-sys tenant.                                                                                          |
-| odp-mode                 | No       | false   | Boolean  | If set to 'true', the connector will connect to OBKV via ODP.                                                 |
-| odp-ip                   | No       |         | String   | IP address of the ODP. Required if 'odp-mode' is set to 'true'.        |
-| odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. Required if 'odp-mode' is set to 'true'.                                             |
-| sys.username             | No       |         | String   | The username of sys tenant. Required if 'odp-mode' is set to 'false'.                                                          |
-| sys.password             | No       |         | String   | The password of sys tenant. Required if 'odp-mode' is set to 'false'.                                                        |
-| hbase.properties         | No       |         | String   | Properties to configure 'obkv-hbase-client-java', multiple values are separated by semicolons.                           |
-| sync-write               | No       | false   | Boolean  | Whether to write data synchronously, will not use buffer if it's set to 'true'.                                          |
-| buffer-flush.interval    | No       | 1s      | Duration | Buffer flush interval. Set '0' to disable scheduled flushing.                                                            |
-| buffer-flush.buffer-size | No       | 1000    | Integer  | Buffer size.                                                                                                             |
-| max-retries              | No       | 3       | Integer  | Max retry times on failure.                                                                                              |
+|          Option          | Required | Default |   Type   |                                                           Description                                                           |
+|--------------------------|----------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------|
+| url                      | No       |         | String   | The config url, can be queried by <code>SHOW PARAMETERS LIKE 'obconfig_url'</code>. Required when 'odp-mode' is set to 'false'. |
+| schema-name              | Yes      |         | String   | The database name of OceanBase.                                                                                                 |
+| table-name               | Yes      |         | String   | The table name of HBase, note that the table name in OceanBase is <code>hbase_table_name$family_name</code>.                    |
+| username                 | Yes      |         | String   | The username of non-sys tenant.                                                                                                 |
+| password                 | Yes      |         | String   | The password of non-sys tenant.                                                                                                 |
+| odp-mode                 | No       | false   | Boolean  | If set to 'true', the connector will connect to OBKV via ODP.                                                                   |
+| odp-ip                   | No       |         | String   | IP address of the ODP. Required if 'odp-mode' is set to 'true'.                                                                 |
+| odp-port                 | No       |         | Integer  | rpc_listen_port of ODP. Required if 'odp-mode' is set to 'true'.                                                                |
+| sys.username             | No       |         | String   | The username of sys tenant. Required if 'odp-mode' is set to 'false'.                                                           |
+| sys.password             | No       |         | String   | The password of sys tenant. Required if 'odp-mode' is set to 'false'.                                                           |
+| hbase.properties         | No       |         | String   | Properties to configure 'obkv-hbase-client-java', multiple values are separated by semicolons.                                  |
+| sync-write               | No       | false   | Boolean  | Whether to write data synchronously, will not use buffer if it's set to 'true'.                                                 |
+| buffer-flush.interval    | No       | 1s      | Duration | Buffer flush interval. Set '0' to disable scheduled flushing.                                                                   |
+| buffer-flush.buffer-size | No       | 1000    | Integer  | Buffer size.                                                                                                                    |
+| max-retries              | No       | 3       | Integer  | Max retry times on failure.                                                                                                     |
 
 ## References
 

--- a/docs/sink/flink-connector-obkv-hbase.md
+++ b/docs/sink/flink-connector-obkv-hbase.md
@@ -72,6 +72,8 @@ CREATE TABLE `htable1$family1`
 
 Take Maven project for example, add the required dependencies to the pom.xml, and then use the following code.
 
+##### obconfig_url mode
+
 ```java
 package com.oceanbase;
 
@@ -113,6 +115,49 @@ public class Main {
 }
 ```
 
+##### odp mode
+
+```java
+package com.oceanbase;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment().setParallelism(1);
+        StreamTableEnvironment tEnv =
+                StreamTableEnvironment.create(
+                        env, EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        tEnv.executeSql(
+                "CREATE TABLE t_sink ( "
+                        + " rowkey STRING,"
+                        + " family1 ROW<column1 STRING, column2 STRING>,"
+                        + " PRIMARY KEY (rowkey) NOT ENFORCED"
+                        + ") with ("
+                        + "  'connector'='obkv-hbase',"
+                        + "  'odp-mode'='true',"
+                        + "  'odp-ip'='127.0.0.1',"
+                        + "  'odp-port'='12881',"
+                        + "  'schema-name'='test',"
+                        + "  'table-name'='htable1',"
+                        + "  'username'='root@test',"
+                        + "  'password'='',"
+                        + ");");
+
+        tEnv.executeSql(
+                        "INSERT INTO t_sink VALUES "
+                                + "('1', ROW('r1f1c1', 'r1f1c2')),"
+                                + "('2', ROW('r2f1c1', 'r2f1c2')),"
+                                + "('2', ROW('r3f1c1', 'r3f1c2'));")
+                .await();
+    }
+}
+```
+
 Once executed, the records should have been written to OceanBase.
 
 For more information please refer to [OBKVHBaseConnectorITCase.java](../../flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java).
@@ -120,6 +165,8 @@ For more information please refer to [OBKVHBaseConnectorITCase.java](../../flink
 #### Flink SQL Demo
 
 Put the JAR files of dependencies to the 'lib' directory of Flink, and then create the destination table with Flink SQL through the sql client.
+
+##### obconfig_url mode
 
 ```sql
 CREATE TABLE t_sink
@@ -131,6 +178,28 @@ CREATE TABLE t_sink
 ) with (
   'connector'='obkv-hbase',
   'url'='http://127.0.0.1:8080/services?...',
+  'schema-name'='test',
+  'table-name'='htable1',
+  'username'='root@test',
+  'password'='',
+  'sys.username'='root',
+  'sys.password'='');
+```
+
+##### odp mode
+
+```sql
+CREATE TABLE t_sink
+(
+  rowkey STRING,
+  family1 ROW <column1 STRING,
+  column2 STRING >,
+  PRIMARY KEY (rowkey) NOT ENFORCED
+) with (
+  'connector'='obkv-hbase',
+  'odp-mode'='true',
+  'odp-ip'='127.0.0.1',
+  'odp-port'='12881',
   'schema-name'='test',
   'table-name'='htable1',
   'username'='root@test',

--- a/docs/sink/flink-connector-obkv-hbase_cn.md
+++ b/docs/sink/flink-connector-obkv-hbase_cn.md
@@ -72,7 +72,7 @@ CREATE TABLE `htable1$family1`
 
 以 Maven 项目为例，将需要的依赖加入到应用的 pom.xml 文件中，然后使用以下代码
 
-##### obconfig_url模式
+##### 使用URL连接
 
 ```java
 package com.oceanbase;
@@ -115,7 +115,7 @@ public class Main {
 }
 ```
 
-##### odp模式
+##### 使用ODP模式连接
 
 ```java
 package com.oceanbase;
@@ -166,7 +166,7 @@ public class Main {
 
 将需要用到的依赖的 JAR 文件放到 Flink 的 lib 目录下，之后通过 SQL Client 在 Flink 中创建目的表。
 
-##### obconfig_url模式
+##### 使用URL连接
 
 ```sql
 CREATE TABLE t_sink
@@ -186,7 +186,7 @@ CREATE TABLE t_sink
   'sys.password'='');
 ```
 
-##### odp模式
+##### 使用ODP模式连接
 
 ```sql
 CREATE TABLE t_sink
@@ -203,9 +203,7 @@ CREATE TABLE t_sink
   'schema-name'='test',
   'table-name'='htable1',
   'username'='root@test',
-  'password'='',
-  'sys.username'='root',
-  'sys.password'='');
+  'password'='');
 ```
 
 插入测试数据

--- a/docs/sink/flink-connector-obkv-hbase_cn.md
+++ b/docs/sink/flink-connector-obkv-hbase_cn.md
@@ -141,7 +141,7 @@ public class Main {
                         + "  'connector'='obkv-hbase',"
                         + "  'odp-mode'='true',"
                         + "  'odp-ip'='127.0.0.1',"
-                        + "  'odp-port'='12881',"
+                        + "  'odp-port'='2885',"
                         + "  'schema-name'='test',"
                         + "  'table-name'='htable1',"
                         + "  'username'='root@test',"
@@ -199,7 +199,7 @@ CREATE TABLE t_sink
   'connector'='obkv-hbase',
   'odp-mode'='true',
   'odp-ip'='127.0.0.1',
-  'odp-port'='12881',
+  'odp-port'='2885',
   'schema-name'='test',
   'table-name'='htable1',
   'username'='root@test',
@@ -228,7 +228,7 @@ VALUES ('1', ROW ('r1f1c1', 'r1f1c2')),
 | table-name               | 是    |       | String   | HBase 表名，注意在 OceanBase 中表名的结构是 <code>hbase_table_name$family_name</code>。                        |
 | username                 | 是    |       | String   | 非 sys 租户的用户名。                                                                                    |
 | password                 | 是    |       | String   | 非 sys 租户的密码。                                                                                     |
-| odp-mode                 | 否    |       | Boolean  | 当 odp-mode 的值为 true 时使用 odp 模式连接 obkv。                                                           |
+| odp-mode                 | 否    | false | Boolean  | 当 odp-mode 的值为 true 时使用 odp 模式连接 obkv。                                                           |
 | odp-ip                   | 否    |       | String   | odp 的 ip，当 odp-mode 的值为 true 时为必填项。                                                              |
 | odp-port                 | 否    |       | Integer  | odp 的 rpc_listen_port，当 odp-mode 的值为 true 时为必填项。                                                 |
 | sys.username             | 否    |       | String   | sys 租户的用户名，当使用 obconfig_url 模式时为必填项。                                                             |

--- a/docs/sink/flink-connector-obkv-hbase_cn.md
+++ b/docs/sink/flink-connector-obkv-hbase_cn.md
@@ -221,20 +221,23 @@ VALUES ('1', ROW ('r1f1c1', 'r1f1c2')),
 
 ## 配置项
 
-|           参数名            | 是否必需 |  默认值  |    类型    |                                    描述                                     |
-|--------------------------|------|-------|----------|---------------------------------------------------------------------------|
-| url                      | 是    |       | String   | 集群的 config url，可以通过 <code>SHOW PARAMETERS LIKE 'obconfig_url'</code> 查询。  |
-| schema-name              | 是    |       | String   | OceanBase 的 db 名。                                                         |
-| table-name               | 是    |       | String   | HBase 表名，注意在 OceanBase 中表名的结构是 <code>hbase_table_name$family_name</code>。 |
-| username                 | 是    |       | String   | 非 sys 租户的用户名。                                                             |
-| password                 | 是    |       | String   | 非 sys 租户的密码。                                                              |
-| sys.username             | 是    |       | String   | sys 租户的用户名。                                                               |
-| sys.password             | 是    |       | String   | sys 租户用户的密码。                                                              |
-| hbase.properties         | 否    |       | String   | 配置 'obkv-hbase-client-java' 的属性，多个值用分号分隔。                                 |
-| sync-write               | 否    | false | Boolean  | 是否开启同步写，设置为 true 时将不使用 buffer 直接写入数据库。                                    |
-| buffer-flush.interval    | 否    | 1s    | Duration | 缓冲区刷新周期。设置为 '0' 时将关闭定期刷新。                                                 |
-| buffer-flush.buffer-size | 否    | 1000  | Integer  | 缓冲区大小。                                                                    |
-| max-retries              | 否    | 3     | Integer  | 失败重试次数。                                                                   |
+|           参数名            | 是否必需 |  默认值  |    类型    |                                               描述                                               |
+|--------------------------|------|-------|----------|------------------------------------------------------------------------------------------------|
+| url                      | 否    |       | String   | 集群的 config url，可以通过 <code>SHOW PARAMETERS LIKE 'obconfig_url'</code> 查询。当使用obconfig_url模式时为必填项 |
+| schema-name              | 是    |       | String   | OceanBase 的 db 名。                                                                              |
+| table-name               | 是    |       | String   | HBase 表名，注意在 OceanBase 中表名的结构是 <code>hbase_table_name$family_name</code>。                      |
+| username                 | 是    |       | String   | 非 sys 租户的用户名。                                                                                  |
+| password                 | 是    |       | String   | 非 sys 租户的密码。                                                                                   |
+| odp-mode                 | 否    |       | Boolean  | 当odp-mode的值为true时使用odp模式连接obkv。                                                                |
+| odp-ip                   | 否    |       | String   | odp的ip，当odp-mode的值为true时为必填项。                                                                  |
+| odp-port                 | 否    |       | Integer  | odp的rpc_listen_port，当odp-mode的值为true时为必填项。                                                     |
+| sys.username             | 否    |       | String   | sys 租户的用户名，当使用obconfig_url模式时为必填项。                                                             |
+| sys.password             | 否    |       | String   | sys 租户用户的密码，当使用obconfig_url模式时为必填项。                                                            |
+| hbase.properties         | 否    |       | String   | 配置 'obkv-hbase-client-java' 的属性，多个值用分号分隔。                                                      |
+| sync-write               | 否    | false | Boolean  | 是否开启同步写，设置为 true 时将不使用 buffer 直接写入数据库。                                                         |
+| buffer-flush.interval    | 否    | 1s    | Duration | 缓冲区刷新周期。设置为 '0' 时将关闭定期刷新。                                                                      |
+| buffer-flush.buffer-size | 否    | 1000  | Integer  | 缓冲区大小。                                                                                         |
+| max-retries              | 否    | 3     | Integer  | 失败重试次数。                                                                                        |
 
 ## 参考信息
 

--- a/docs/sink/flink-connector-obkv-hbase_cn.md
+++ b/docs/sink/flink-connector-obkv-hbase_cn.md
@@ -221,23 +221,23 @@ VALUES ('1', ROW ('r1f1c1', 'r1f1c2')),
 
 ## 配置项
 
-|           参数名            | 是否必需 |  默认值  |    类型    |                                               描述                                               |
-|--------------------------|------|-------|----------|------------------------------------------------------------------------------------------------|
-| url                      | 否    |       | String   | 集群的 config url，可以通过 <code>SHOW PARAMETERS LIKE 'obconfig_url'</code> 查询。当使用obconfig_url模式时为必填项 |
-| schema-name              | 是    |       | String   | OceanBase 的 db 名。                                                                              |
-| table-name               | 是    |       | String   | HBase 表名，注意在 OceanBase 中表名的结构是 <code>hbase_table_name$family_name</code>。                      |
-| username                 | 是    |       | String   | 非 sys 租户的用户名。                                                                                  |
-| password                 | 是    |       | String   | 非 sys 租户的密码。                                                                                   |
-| odp-mode                 | 否    |       | Boolean  | 当odp-mode的值为true时使用odp模式连接obkv。                                                                |
-| odp-ip                   | 否    |       | String   | odp的ip，当odp-mode的值为true时为必填项。                                                                  |
-| odp-port                 | 否    |       | Integer  | odp的rpc_listen_port，当odp-mode的值为true时为必填项。                                                     |
-| sys.username             | 否    |       | String   | sys 租户的用户名，当使用obconfig_url模式时为必填项。                                                             |
-| sys.password             | 否    |       | String   | sys 租户用户的密码，当使用obconfig_url模式时为必填项。                                                            |
-| hbase.properties         | 否    |       | String   | 配置 'obkv-hbase-client-java' 的属性，多个值用分号分隔。                                                      |
-| sync-write               | 否    | false | Boolean  | 是否开启同步写，设置为 true 时将不使用 buffer 直接写入数据库。                                                         |
-| buffer-flush.interval    | 否    | 1s    | Duration | 缓冲区刷新周期。设置为 '0' 时将关闭定期刷新。                                                                      |
-| buffer-flush.buffer-size | 否    | 1000  | Integer  | 缓冲区大小。                                                                                         |
-| max-retries              | 否    | 3     | Integer  | 失败重试次数。                                                                                        |
+|           参数名            | 是否必需 |  默认值  |    类型    |                                                描述                                                |
+|--------------------------|------|-------|----------|--------------------------------------------------------------------------------------------------|
+| url                      | 否    |       | String   | 集群的 config url，可以通过 <code>SHOW PARAMETERS LIKE 'obconfig_url'</code> 查询。当使用 obconfig_url 模式时为必填项 |
+| schema-name              | 是    |       | String   | OceanBase 的 db 名。                                                                                |
+| table-name               | 是    |       | String   | HBase 表名，注意在 OceanBase 中表名的结构是 <code>hbase_table_name$family_name</code>。                        |
+| username                 | 是    |       | String   | 非 sys 租户的用户名。                                                                                    |
+| password                 | 是    |       | String   | 非 sys 租户的密码。                                                                                     |
+| odp-mode                 | 否    |       | Boolean  | 当 odp-mode 的值为 true 时使用 odp 模式连接 obkv。                                                           |
+| odp-ip                   | 否    |       | String   | odp 的 ip，当 odp-mode 的值为 true 时为必填项。                                                              |
+| odp-port                 | 否    |       | Integer  | odp 的 rpc_listen_port，当 odp-mode 的值为 true 时为必填项。                                                 |
+| sys.username             | 否    |       | String   | sys 租户的用户名，当使用 obconfig_url 模式时为必填项。                                                             |
+| sys.password             | 否    |       | String   | sys 租户用户的密码，当使用 obconfig_url 模式时为必填项。                                                            |
+| hbase.properties         | 否    |       | String   | 配置 'obkv-hbase-client-java' 的属性，多个值用分号分隔。                                                        |
+| sync-write               | 否    | false | Boolean  | 是否开启同步写，设置为 true 时将不使用 buffer 直接写入数据库。                                                           |
+| buffer-flush.interval    | 否    | 1s    | Duration | 缓冲区刷新周期。设置为 '0' 时将关闭定期刷新。                                                                        |
+| buffer-flush.buffer-size | 否    | 1000  | Integer  | 缓冲区大小。                                                                                           |
+| max-retries              | 否    | 3     | Integer  | 失败重试次数。                                                                                          |
 
 ## 参考信息
 

--- a/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseConnectorOptions.java
+++ b/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseConnectorOptions.java
@@ -51,6 +51,16 @@ public class OBKVHBaseConnectorOptions extends ConnectorOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("When in ODP mode, the url should be odp-ip:odp-port.");
+    public static final ConfigOption<String> ODP_IP =
+            ConfigOptions.key("odp-ip")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("ODP IP, please fill in it when using the ODP mode.");
+    public static final ConfigOption<Integer> ODP_PORT =
+            ConfigOptions.key("odp-port")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("ODP port, please fill in it when using the ODP mode.");
 
     public OBKVHBaseConnectorOptions(Map<String, String> config) {
         super(config);
@@ -70,5 +80,13 @@ public class OBKVHBaseConnectorOptions extends ConnectorOptions {
 
     public Boolean getOdpMode() {
         return allConfig.get(ODP_MODE);
+    }
+
+    public String getOdpIP() {
+        return allConfig.get(ODP_IP);
+    }
+
+    public Integer getOdpPort() {
+        return allConfig.get(ODP_PORT);
     }
 }

--- a/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseDynamicTableSinkFactory.java
+++ b/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseDynamicTableSinkFactory.java
@@ -62,7 +62,6 @@ public class OBKVHBaseDynamicTableSinkFactory implements DynamicTableSinkFactory
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(OBKVHBaseConnectorOptions.URL);
         options.add(OBKVHBaseConnectorOptions.USERNAME);
         options.add(OBKVHBaseConnectorOptions.PASSWORD);
         options.add(OBKVHBaseConnectorOptions.SCHEMA_NAME);
@@ -73,7 +72,10 @@ public class OBKVHBaseDynamicTableSinkFactory implements DynamicTableSinkFactory
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(OBKVHBaseConnectorOptions.URL);
         options.add(OBKVHBaseConnectorOptions.ODP_MODE);
+        options.add(OBKVHBaseConnectorOptions.ODP_IP);
+        options.add(OBKVHBaseConnectorOptions.ODP_PORT);
         options.add(OBKVHBaseConnectorOptions.SYS_USERNAME);
         options.add(OBKVHBaseConnectorOptions.SYS_PASSWORD);
         options.add(OBKVHBaseConnectorOptions.SYNC_WRITE);

--- a/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/connection/OBKVHBaseConnectionProvider.java
+++ b/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/connection/OBKVHBaseConnectionProvider.java
@@ -18,7 +18,6 @@ package com.oceanbase.connector.flink.connection;
 
 import com.oceanbase.connector.flink.OBKVHBaseConnectorOptions;
 import com.oceanbase.connector.flink.table.TableId;
-import com.oceanbase.connector.flink.utils.OptionUtils;
 import com.oceanbase.connector.flink.utils.TableCache;
 
 import com.alipay.oceanbase.hbase.OHTableClient;
@@ -66,12 +65,8 @@ public class OBKVHBaseConnectionProvider implements ConnectionProvider {
         Configuration conf = new Configuration();
         if (options.getOdpMode()) {
             conf.setBoolean(OHConstants.HBASE_OCEANBASE_ODP_MODE, options.getOdpMode());
-            conf.set(
-                    OHConstants.HBASE_OCEANBASE_ODP_ADDR,
-                    OptionUtils.getIpAndPort(options.getUrl())[0]);
-            conf.setInt(
-                    OHConstants.HBASE_OCEANBASE_ODP_PORT,
-                    Integer.parseInt(OptionUtils.getIpAndPort(options.getUrl())[1]));
+            conf.set(OHConstants.HBASE_OCEANBASE_ODP_ADDR, options.getOdpIP());
+            conf.setInt(OHConstants.HBASE_OCEANBASE_ODP_PORT, options.getOdpPort());
             conf.set(OHConstants.HBASE_OCEANBASE_DATABASE, databaseName);
         } else {
             String paramUrl = String.format("%s&database=%s", options.getUrl(), databaseName);

--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -61,8 +61,8 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
 
             Map<String, String> options = getOptions();
             options.put("odp-mode", "true");
-            options.put("url", odpContainer.getHost() + ":" + odpContainer.getRpcPort());
-
+            options.put("odp-ip", odpContainer.getHost());
+            options.put("odp-port", odpContainer.getRpcPort());
             testSinkToHTable(options);
         }
     }

--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -62,7 +62,7 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
             Map<String, String> options = getOptions();
             options.put("odp-mode", "true");
             options.put("odp-ip", odpContainer.getHost());
-            options.put("odp-port", odpContainer.getRpcPort());
+            options.put("odp-port", String.valueOf(odpContainer.getRpcPort()));
             testSinkToHTable(options);
         }
     }

--- a/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/utils/OptionUtils.java
+++ b/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/utils/OptionUtils.java
@@ -57,12 +57,4 @@ public class OptionUtils {
         }
         return props;
     }
-
-    public static String[] getIpAndPort(String url) {
-        if (StringUtils.isNotBlank(url)) {
-            return url.split(":");
-        } else {
-            throw new IllegalArgumentException("The URL is not up to specification");
-        }
-    }
 }

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -74,7 +74,7 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
         return getMappedPort(SQL_PORT);
     }
 
-    public String getRpcPort() {
-        return String.valueOf(getMappedPort(RPC_PORT));
+    public int getRpcPort() {
+        return getMappedPort(RPC_PORT);
     }
 }

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -74,7 +74,7 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
         return getMappedPort(SQL_PORT);
     }
 
-    public int getRpcPort() {
-        return getMappedPort(RPC_PORT);
+    public String getRpcPort() {
+        return String.valueOf(getMappedPort(RPC_PORT));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In ODP mode, you can use ODP-IP and ODP-PORT to connect to the network, and you can leave the URL blank when using ODP mode. close #84 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Take a look at this unit test.com.oceanbase.connector.flink.OBKVHBaseConnectorITCase