### PR TITLE
test: use standalone ob-configserver docker container

### DIFF
--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -41,15 +41,15 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
     public static void setup() throws Exception {
         CONFIG_SERVER.start();
 
-        CONTAINER
-                .withEnv(
-                        "OB_CONFIGSERVER_ADDRESS",
-                        "http://" + getContainerIP(CONFIG_SERVER) + ":8080")
-                .start();
+        String configServerAddress = getConfigServerAddress(CONFIG_SERVER);
+        String configUrlForODP = configServerAddress + "/services?Action=GetObProxyConfig";
+
+        CONTAINER.withEnv("OB_CONFIGSERVER_ADDRESS", configServerAddress).start();
 
         String password = "test";
         createSysUser("proxyro", password);
-        ODP.withPassword(password).withRsList(getContainerIP(CONTAINER) + ":2882").start();
+
+        ODP.withPassword(password).withConfigUrl(configUrlForODP).start();
     }
 
     @AfterClass

--- a/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
+++ b/flink-connector-obkv-hbase/src/test/java/com/oceanbase/connector/flink/OBKVHBaseConnectorITCase.java
@@ -42,7 +42,7 @@ public class OBKVHBaseConnectorITCase extends OceanBaseMySQLTestBase {
         CONFIG_SERVER.start();
 
         String configServerAddress = getConfigServerAddress(CONFIG_SERVER);
-        String configUrlForODP = configServerAddress + "/services?Action=GetObProxyConfig";
+        String configUrlForODP = constructConfigUrlForODP(configServerAddress);
 
         CONTAINER.withEnv("OB_CONFIGSERVER_ADDRESS", configServerAddress).start();
 

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -74,7 +74,6 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
     public static final OceanBaseProxyContainer ODP =
             new OceanBaseProxyContainer("4.3.1.0-4")
                     .withNetwork(NETWORK)
-                    .withClusterName(CLUSTER_NAME)
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     public static String getContainerIP(GenericContainer<?> container) {

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -39,6 +39,7 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
     private static final int SQL_PORT = 2881;
     private static final int RPC_PORT = 2882;
     private static final int CONFIG_SERVER_PORT = 8080;
+    private static final String CONFIG_URL_PATH = "/services?Action=GetObProxyConfig";
 
     private static final String CLUSTER_NAME = "flink-oceanbase-ci";
     private static final String TEST_TENANT = "flink";
@@ -55,7 +56,7 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
                     .waitingFor(
                             new HttpWaitStrategy()
                                     .forPort(CONFIG_SERVER_PORT)
-                                    .forPath("/services?Action=GetObProxyConfig"))
+                                    .forPath(CONFIG_URL_PATH))
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     public static final OceanBaseCEContainer CONTAINER =
@@ -92,6 +93,10 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
     public static String getConfigServerAddress(GenericContainer<?> container) {
         String ip = getContainerIP(container);
         return "http://" + ip + ":" + CONFIG_SERVER_PORT;
+    }
+
+    public static String constructConfigUrlForODP(String address) {
+        return address + CONFIG_URL_PATH;
     }
 
     public static Connection getSysJdbcConnection() throws SQLException {

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLTestBase.java
@@ -90,6 +90,11 @@ public abstract class OceanBaseMySQLTestBase extends OceanBaseTestBase {
         return ip;
     }
 
+    public static String getConfigServerAddress(GenericContainer<?> container) {
+        String ip = getContainerIP(container);
+        return "http://" + ip + ":" + CONFIG_SERVER_PORT;
+    }
+
     public static Connection getSysJdbcConnection() throws SQLException {
         String jdbcUrl =
                 "jdbc:mysql://"

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -61,7 +61,7 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
 
     @Override
     public String getUsername() {
-        return "proxyro";
+        return "proxyro@sys#" + clusterName;
     }
 
     @Override

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -16,15 +16,10 @@
 
 package com.oceanbase.connector.flink;
 
-import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyContainer> {
+public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProxyContainer> {
 
     private static final String IMAGE = "oceanbase/obproxy-ce";
 
@@ -50,9 +45,33 @@ public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyCont
         addEnv("PROXYRO_PASSWORD", password);
     }
 
-    public @NotNull Set<Integer> getLivenessCheckPortNumbers() {
-        return new HashSet<>(
-                Arrays.asList(this.getMappedPort(SQL_PORT), this.getMappedPort(RPC_PORT)));
+    @Override
+    public String getDriverClassName() {
+        return "com.mysql.cj.jdbc.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:mysql://"
+                + getHost()
+                + ":"
+                + getSqlPort()
+                + "/?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
+    }
+
+    @Override
+    public String getUsername() {
+        return "proxyro";
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
     }
 
     public OceanBaseProxyContainer withClusterName(String clusterName) {

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -16,12 +16,12 @@
 
 package com.oceanbase.connector.flink;
 
-import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Objects;
 
-public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProxyContainer> {
+public class OceanBaseProxyContainer extends GenericContainer<OceanBaseProxyContainer> {
 
     private static final String IMAGE = "oceanbase/obproxy-ce";
 
@@ -29,7 +29,6 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
     private static final int RPC_PORT = 2885;
     private static final String APP_NAME = "flink_oceanbase_test";
 
-    private String clusterName = "obcluster";
     private String configUrl;
     private String password;
 
@@ -43,40 +42,6 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
         addEnv("APP_NAME", APP_NAME);
         addEnv("CONFIG_URL", Objects.requireNonNull(configUrl));
         addEnv("PROXYRO_PASSWORD", Objects.requireNonNull(password));
-    }
-
-    @Override
-    public String getDriverClassName() {
-        return "com.mysql.cj.jdbc.Driver";
-    }
-
-    @Override
-    public String getJdbcUrl() {
-        return "jdbc:mysql://"
-                + getHost()
-                + ":"
-                + getSqlPort()
-                + "/?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
-    }
-
-    @Override
-    public String getUsername() {
-        return "proxyro@sys#" + clusterName;
-    }
-
-    @Override
-    public String getPassword() {
-        return password;
-    }
-
-    @Override
-    protected String getTestQueryString() {
-        return "SELECT 1";
-    }
-
-    public OceanBaseProxyContainer withClusterName(String clusterName) {
-        this.clusterName = clusterName;
-        return this;
     }
 
     public OceanBaseProxyContainer withConfigUrl(String configUrl) {

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseProxyContainer.java
@@ -19,6 +19,8 @@ package com.oceanbase.connector.flink;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.Objects;
+
 public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProxyContainer> {
 
     private static final String IMAGE = "oceanbase/obproxy-ce";
@@ -28,7 +30,7 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
     private static final String APP_NAME = "flink_oceanbase_test";
 
     private String clusterName = "obcluster";
-    private String rsList;
+    private String configUrl;
     private String password;
 
     public OceanBaseProxyContainer(String version) {
@@ -38,11 +40,9 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
 
     @Override
     protected void configure() {
-        assert rsList != null && password != null;
         addEnv("APP_NAME", APP_NAME);
-        addEnv("OB_CLUSTER", clusterName);
-        addEnv("RS_LIST", rsList);
-        addEnv("PROXYRO_PASSWORD", password);
+        addEnv("CONFIG_URL", Objects.requireNonNull(configUrl));
+        addEnv("PROXYRO_PASSWORD", Objects.requireNonNull(password));
     }
 
     @Override
@@ -79,8 +79,8 @@ public class OceanBaseProxyContainer extends JdbcDatabaseContainer<OceanBaseProx
         return this;
     }
 
-    public OceanBaseProxyContainer withRsList(String rsList) {
-        this.rsList = rsList;
+    public OceanBaseProxyContainer withConfigUrl(String configUrl) {
+        this.configUrl = configUrl;
         return this;
     }
 

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseTestBase.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/OceanBaseTestBase.java
@@ -86,33 +86,6 @@ public abstract class OceanBaseTestBase implements OceanBaseMetadata {
         return DriverManager.getConnection(getJdbcUrl(), getUsername(), getPassword());
     }
 
-    public Connection getSysJdbcConnection() throws SQLException {
-        return DriverManager.getConnection(getJdbcUrl(), getSysUsername(), getSysPassword());
-    }
-
-    public String getSysParameter(String parameter) {
-        try (Connection connection = getSysJdbcConnection();
-                Statement statement = connection.createStatement()) {
-            String sql = String.format("SHOW PARAMETERS LIKE '%s'", parameter);
-            ResultSet rs = statement.executeQuery(sql);
-            if (rs.next()) {
-                return rs.getString("VALUE");
-            }
-            throw new RuntimeException("Parameter '" + parameter + "' not found");
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void createSysUser(String user, String password) throws SQLException {
-        assert user != null && password != null;
-        try (Connection connection = getSysJdbcConnection();
-                Statement statement = connection.createStatement()) {
-            statement.execute("CREATE USER '" + user + "' IDENTIFIED BY '" + password + "'");
-            statement.execute("GRANT ALL PRIVILEGES ON *.* TO '" + user + "'@'%'");
-        }
-    }
-
     public void initialize(String sqlFile) {
         final URL file = getClass().getClassLoader().getResource(sqlFile);
         assertNotNull("Cannot locate " + sqlFile, file);

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.types.RowKind;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -53,6 +55,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        CONTAINER.start();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        CONTAINER.stop();
+    }
 
     @Test
     public void testSink() throws Exception {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

The latest `oceanbase/oceanabase-ce` docker image does not contain config server, so we need to start a new container for it.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
