### PR TITLE
feat: add sink.parallelism support for OceanBase JDBC connector

### DIFF
--- a/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseDynamicTableSinkFactory.java
+++ b/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/OBKVHBaseDynamicTableSinkFactory.java
@@ -85,6 +85,7 @@ public class OBKVHBaseDynamicTableSinkFactory implements DynamicTableSinkFactory
         options.add(OBKVHBaseConnectorOptions.BUFFER_SIZE);
         options.add(OBKVHBaseConnectorOptions.MAX_RETRIES);
         options.add(OBKVHBaseConnectorOptions.HBASE_PROPERTIES);
+        options.add(ConnectorOptions.SINK_PARALLELISM);
         return options;
     }
 

--- a/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/sink/OBKVHBaseDynamicTableSink.java
+++ b/flink-connector-obkv-hbase/src/main/java/com/oceanbase/connector/flink/sink/OBKVHBaseDynamicTableSink.java
@@ -49,7 +49,8 @@ public class OBKVHBaseDynamicTableSink extends AbstractDynamicTableSink {
                                                         connectorOptions.getTableName()),
                                                 physicalSchema)),
                                 DataChangeRecord.KeyExtractor.simple(),
-                                new OBKVHBaseRecordFlusher(connectorOptions)));
+                                new OBKVHBaseRecordFlusher(connectorOptions)),
+                connectorOptions.getSinkParallelism());
     }
 
     @Override

--- a/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/ConnectorOptions.java
+++ b/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/ConnectorOptions.java
@@ -84,6 +84,15 @@ public abstract class ConnectorOptions implements Serializable {
                     .withDescription(
                             "The max retry times if writing records to database failed. Default value is '3'.");
 
+    public static final ConfigOption<Integer> SINK_PARALLELISM =
+            ConfigOptions.key("sink.parallelism")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Defines a custom parallelism for the sink. "
+                                    + "By default, if this option is not defined, the sink parallelism will be "
+                                    + "determined by the execution environment.");
+
     protected final ReadableConfig allConfig;
 
     public ConnectorOptions(Map<String, String> config) {
@@ -124,5 +133,9 @@ public abstract class ConnectorOptions implements Serializable {
 
     public int getMaxRetries() {
         return allConfig.get(MAX_RETRIES);
+    }
+
+    public Integer getSinkParallelism() {
+        return allConfig.get(SINK_PARALLELISM);
     }
 }

--- a/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
+++ b/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
@@ -91,7 +91,12 @@ public abstract class AbstractDynamicTableSink implements DynamicTableSink {
                     objectReuse
                             ? dataStream.getType().createSerializer(dataStream.getExecutionConfig())
                             : null;
-            return dataStream.sinkTo(sinkSupplier.apply(typeSerializer));
+            DataStreamSink<?> dataStreamSink =
+                    dataStream.sinkTo(sinkSupplier.apply(typeSerializer));
+            if (parallelism != null) {
+                dataStreamSink.setParallelism(parallelism);
+            }
+            return dataStreamSink;
         }
     }
 }

--- a/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
+++ b/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
@@ -30,6 +30,7 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.function.SerializableFunction;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -63,10 +64,18 @@ public abstract class AbstractDynamicTableSink implements DynamicTableSink {
         private static final long serialVersionUID = 1L;
 
         private final SerializableFunction<TypeSerializer<RowData>, Sink<RowData>> sinkSupplier;
+        private final Integer parallelism;
 
         public SinkProvider(
-                SerializableFunction<TypeSerializer<RowData>, Sink<RowData>> sinkSupplier) {
+                SerializableFunction<TypeSerializer<RowData>, Sink<RowData>> sinkSupplier,
+                Integer parallelism) {
             this.sinkSupplier = sinkSupplier;
+            this.parallelism = parallelism;
+        }
+
+        @Override
+        public Optional<Integer> getParallelism() {
+            return Optional.ofNullable(parallelism);
         }
 
         @Override

--- a/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
+++ b/flink-connector-oceanbase-base/src/main/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSink.java
@@ -69,6 +69,10 @@ public abstract class AbstractDynamicTableSink implements DynamicTableSink {
         public SinkProvider(
                 SerializableFunction<TypeSerializer<RowData>, Sink<RowData>> sinkSupplier,
                 Integer parallelism) {
+            checkState(
+                    parallelism == null || parallelism > 0,
+                    "sink.parallelism must be a positive integer, but got: %s",
+                    parallelism);
             this.sinkSupplier = sinkSupplier;
             this.parallelism = parallelism;
         }

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSinkTest.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSinkTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oceanbase.connector.flink.sink;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link AbstractDynamicTableSink}. */
+public class AbstractDynamicTableSinkTest {
+
+    @Test
+    public void testSinkProviderWithParallelism() {
+        // Test with parallelism set
+        AbstractDynamicTableSink.SinkProvider providerWithParallelism =
+                new AbstractDynamicTableSink.SinkProvider(typeSerializer -> null, 4);
+
+        Optional<Integer> parallelism = providerWithParallelism.getParallelism();
+        assertTrue(parallelism.isPresent());
+        assertEquals(4, parallelism.get());
+    }
+
+    @Test
+    public void testSinkProviderWithoutParallelism() {
+        // Test without parallelism set (null)
+        AbstractDynamicTableSink.SinkProvider providerWithoutParallelism =
+                new AbstractDynamicTableSink.SinkProvider(typeSerializer -> null, null);
+
+        Optional<Integer> parallelism = providerWithoutParallelism.getParallelism();
+        assertFalse(parallelism.isPresent());
+    }
+}

--- a/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSinkTest.java
+++ b/flink-connector-oceanbase-base/src/test/java/com/oceanbase/connector/flink/sink/AbstractDynamicTableSinkTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link AbstractDynamicTableSink}. */
@@ -46,5 +47,15 @@ public class AbstractDynamicTableSinkTest {
 
         Optional<Integer> parallelism = providerWithoutParallelism.getParallelism();
         assertFalse(parallelism.isPresent());
+    }
+
+    @Test
+    public void testSinkProviderWithInvalidParallelism() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> new AbstractDynamicTableSink.SinkProvider(typeSerializer -> null, 0));
+        assertThrows(
+                IllegalStateException.class,
+                () -> new AbstractDynamicTableSink.SinkProvider(typeSerializer -> null, -1));
     }
 }

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/OceanBaseDynamicTableSinkFactory.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/OceanBaseDynamicTableSinkFactory.java
@@ -85,6 +85,7 @@ public class OceanBaseDynamicTableSinkFactory implements DynamicTableSinkFactory
         options.add(OceanBaseConnectorOptions.MEMSTORE_CHECK_INTERVAL);
         options.add(OceanBaseConnectorOptions.PARTITION_ENABLED);
         options.add(OceanBaseConnectorOptions.TABLE_ORACLE_TENANT_CASE_INSENSITIVE);
+        options.add(ConnectorOptions.SINK_PARALLELISM);
         // Tolerate source-only options since both factories share the "oceanbase" identifier
         options.add(OceanBaseTableSourceFactory.COMPATIBLE_MODE);
         options.add(OceanBaseTableSourceFactory.SPLIT_SIZE);

--- a/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseDynamicTableSink.java
+++ b/flink-connector-oceanbase/src/main/java/com/oceanbase/connector/flink/sink/OceanBaseDynamicTableSink.java
@@ -55,7 +55,8 @@ public class OceanBaseDynamicTableSink extends AbstractDynamicTableSink {
                                 new OceanBaseRowDataSerializationSchema(
                                         new TableInfo(tableId, physicalSchema)),
                                 DataChangeRecord.KeyExtractor.simple(),
-                                recordFlusher));
+                                recordFlusher),
+                connectorOptions.getSinkParallelism());
     }
 
     @Override

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -491,6 +491,21 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
                         + "  'fields.id.end' = '209'"
                         + ");");
 
+        // Get execution plan and verify sink parallelism
+        org.apache.flink.table.api.TableResult explainResult =
+                tEnv.executeSql(
+                        "EXPLAIN JSON_EXECUTION_PLAN "
+                                + "INSERT INTO target_parallel "
+                                + "SELECT id, name, description, weight FROM source_parallel");
+
+        String explainPlan = explainResult.collect().next().getField(0).toString();
+
+        // Verify the execution plan contains sink with parallelism 4
+        assertTrue(
+                "Execution plan should contain Sink with parallelism 4",
+                explainPlan.contains("\"parallelism\" : 4")
+                        || explainPlan.contains("\"parallelism\":4"));
+
         // Execute INSERT
         tEnv.executeSql(
                         "INSERT INTO target_parallel "

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -500,11 +500,17 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
 
         String explainPlan = explainResult.collect().next().getField(0).toString();
 
+        // Print execution plan for debugging
+        LOG.info("Execution plan: {}", explainPlan);
+
         // Verify the execution plan contains sink with parallelism 4
+        // The parallelism may appear in different formats depending on Flink version
         assertTrue(
-                "Execution plan should contain Sink with parallelism 4",
+                "Execution plan should contain Sink with parallelism 4. Actual plan: "
+                        + explainPlan,
                 explainPlan.contains("\"parallelism\" : 4")
-                        || explainPlan.contains("\"parallelism\":4"));
+                        || explainPlan.contains("\"parallelism\":4")
+                        || explainPlan.contains("parallelism=4"));
 
         // Execute INSERT
         tEnv.executeSql(

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -450,4 +450,60 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
         }
         return sb.toString();
     }
+
+    @Test
+    public void testSinkParallelism() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1); // Default parallelism
+        StreamTableEnvironment tEnv =
+                StreamTableEnvironment.create(
+                        env, EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        initialize("sql/mysql/products.sql");
+
+        // Create sink table with sink.parallelism = 4
+        tEnv.executeSql(
+                "CREATE TEMPORARY TABLE target_parallel ("
+                        + " `id` INT NOT NULL,"
+                        + " name STRING,"
+                        + " description STRING,"
+                        + " weight DECIMAL(20, 10),"
+                        + " PRIMARY KEY (`id`) NOT ENFORCED"
+                        + ") with ("
+                        + "  'connector'='oceanbase',"
+                        + "  'table-name'='products',"
+                        + "  'sink.parallelism' = '4',"
+                        + getOptionsString()
+                        + ");");
+
+        // Create a simple source table
+        tEnv.executeSql(
+                "CREATE TEMPORARY TABLE source_parallel ("
+                        + " `id` INT NOT NULL,"
+                        + " name STRING,"
+                        + " description STRING,"
+                        + " weight DECIMAL(20, 10)"
+                        + ") WITH ("
+                        + "  'connector' = 'datagen',"
+                        + "  'number-of-rows' = '10',"
+                        + "  'fields.id.kind' = 'sequence',"
+                        + "  'fields.id.start' = '200',"
+                        + "  'fields.id.end' = '209'"
+                        + ");");
+
+        // Execute INSERT
+        tEnv.executeSql(
+                        "INSERT INTO target_parallel "
+                                + "SELECT id, name, description, weight FROM source_parallel")
+                .await();
+
+        // Verify data was written
+        waitingAndAssertTableCount("products", 10);
+
+        // Verify the execution plan contains the parallelism setting
+        // Note: The parallelism is applied at runtime, so we verify it through the SinkProvider
+        // The data being written correctly indicates the sink works with the parallelism setting
+
+        dropTables("products");
+    }
 }

--- a/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
+++ b/flink-connector-oceanbase/src/test/java/com/oceanbase/connector/flink/OceanBaseMySQLConnectorITCase.java
@@ -500,10 +500,6 @@ public class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
         // Verify data was written
         waitingAndAssertTableCount("products", 10);
 
-        // Verify the execution plan contains the parallelism setting
-        // Note: The parallelism is applied at runtime, so we verify it through the SinkProvider
-        // The data being written correctly indicates the sink works with the parallelism setting
-
         dropTables("products");
     }
 }


### PR DESCRIPTION
## Summary
- Add support for configuring sink parallelism via `sink.parallelism` option in SQL DDL or Table Hints
- Users can now set a custom parallelism for the sink operator

## Changes
- Add `SINK_PARALLELISM` config option in `ConnectorOptions`
- Modify `SinkProvider` to support parallelism via `getParallelism()` method
- Register the option in `OceanBaseDynamicTableSinkFactory`
- Pass parallelism parameter in `OceanBaseDynamicTableSink`
- Add unit test for `SinkProvider` parallelism
- Add integration test for `sink.parallelism` configuration

## Usage

### DDL Configuration
```sql
CREATE TABLE ob_sink (
    id INT,
    name STRING
) WITH (
    'connector' = 'oceanbase',
    'url' = 'jdbc:mysql://localhost:2881/test',
    'username' = 'root',
    'password' = 'password',
    'schema-name' = 'test',
    'table-name' = 'sink_table',
    'sink.parallelism' = '4'
);
```

### Table Hints
```sql
INSERT INTO ob_sink /*+ OPTIONS('sink.parallelism' = '8') */
SELECT * FROM source_table;
```

## Test Plan
- [x] Unit test: `AbstractDynamicTableSinkTest` verifies `getParallelism()` returns correct value
- [x] Integration test: `testSinkParallelism` in `OceanBaseMySQLConnectorITCase`
- [ ] GitHub CI passes